### PR TITLE
Add github portfolio module

### DIFF
--- a/modules/mod_github_portfolio/language/en-GB/mod_github_portfolio.ini
+++ b/modules/mod_github_portfolio/language/en-GB/mod_github_portfolio.ini
@@ -1,0 +1,8 @@
+MOD_GITHUB_PORTFOLIO="GitHub Portfolio"
+MOD_GITHUB_PORTFOLIO_XML_DESCRIPTION="Displays recent GitHub pull requests for a specified user"
+MOD_GITHUB_PORTFOLIO_FIELD_USERNAME_LABEL="GitHub Username"
+MOD_GITHUB_PORTFOLIO_FIELD_USERNAME_DESC="Enter the GitHub username to display pull requests for"
+MOD_GITHUB_PORTFOLIO_FIELD_MAX_ITEMS_LABEL="Maximum Items"
+MOD_GITHUB_PORTFOLIO_FIELD_MAX_ITEMS_DESC="Maximum number of pull requests to display (1-30)"
+MOD_GITHUB_PORTFOLIO_FIELD_CACHE_TIME_LABEL="Cache Time (minutes)"
+MOD_GITHUB_PORTFOLIO_FIELD_CACHE_TIME_DESC="How long to cache GitHub API data in minutes"

--- a/modules/mod_github_portfolio/language/en-GB/mod_github_portfolio.sys.ini
+++ b/modules/mod_github_portfolio/language/en-GB/mod_github_portfolio.sys.ini
@@ -1,0 +1,2 @@
+MOD_GITHUB_PORTFOLIO="GitHub Portfolio"
+MOD_GITHUB_PORTFOLIO_XML_DESCRIPTION="Displays recent GitHub pull requests for a specified user"

--- a/modules/mod_github_portfolio/mod_github_portfolio.xml
+++ b/modules/mod_github_portfolio/mod_github_portfolio.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="module" client="site" method="upgrade">
+    <name>MOD_GITHUB_PORTFOLIO</name>
+    <author>Alikon</author>
+    <creationDate>2025-12-01</creationDate>
+    <version>1.0.0</version>
+    <description>MOD_GITHUB_PORTFOLIO_XML_DESCRIPTION</description>
+    <namespace path="src">Joomla\Module\GithubPortfolio</namespace>
+    <files>
+        <folder module="mod_github_portfolio">services</folder>
+        <folder>src</folder>
+        <folder>tmpl</folder>
+    </files>
+    <languages>
+        <language tag="en-GB">language/en-GB/mod_github_portfolio.ini</language>
+        <language tag="en-GB">language/en-GB/mod_github_portfolio.sys.ini</language>
+    </languages>
+    <config>
+        <fields name="params">
+            <fieldset name="basic">
+                <field
+                    name="github_username"
+                    type="text"
+                    label="MOD_GITHUB_PORTFOLIO_FIELD_USERNAME_LABEL"
+                    description="MOD_GITHUB_PORTFOLIO_FIELD_USERNAME_DESC"
+                    default="alikon"
+                    required="true"
+                />
+                <field
+                    name="max_items"
+                    type="number"
+                    label="MOD_GITHUB_PORTFOLIO_FIELD_MAX_ITEMS_LABEL"
+                    description="MOD_GITHUB_PORTFOLIO_FIELD_MAX_ITEMS_DESC"
+                    default="6"
+                    min="1"
+                    max="30"
+                />
+                <field
+                    name="cache_time"
+                    type="number"
+                    label="MOD_GITHUB_PORTFOLIO_FIELD_CACHE_TIME_LABEL"
+                    description="MOD_GITHUB_PORTFOLIO_FIELD_CACHE_TIME_DESC"
+                    default="15"
+                    min="1"
+                />
+            </fieldset>
+        </fields>
+    </config>
+</extension>

--- a/modules/mod_github_portfolio/mod_github_portfolio.xml
+++ b/modules/mod_github_portfolio/mod_github_portfolio.xml
@@ -6,6 +6,9 @@
     <version>1.0.0</version>
     <description>MOD_GITHUB_PORTFOLIO_XML_DESCRIPTION</description>
     <namespace path="src">Joomla\Module\GithubPortfolio</namespace>
+    <media destination="mod_github_portfolio" folder="media">
+        <folder>js</folder>
+    </media>
     <files>
         <folder module="mod_github_portfolio">services</folder>
         <folder>src</folder>

--- a/modules/mod_github_portfolio/services/provider.php
+++ b/modules/mod_github_portfolio/services/provider.php
@@ -1,0 +1,16 @@
+<?php
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\Service\Provider\Module;
+use Joomla\CMS\Extension\Service\Provider\ModuleDispatcherFactory;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+return new class () implements ServiceProviderInterface {
+    public function register(Container $container): void
+    {
+        $container->registerServiceProvider(new ModuleDispatcherFactory('\\Joomla\\Module\\GithubPortfolio'));
+        $container->registerServiceProvider(new Module());
+    }
+};

--- a/modules/mod_github_portfolio/src/Dispatcher/Dispatcher.php
+++ b/modules/mod_github_portfolio/src/Dispatcher/Dispatcher.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Joomla\Module\GithubPortfolio\Site\Dispatcher;
+
+use Joomla\CMS\Dispatcher\AbstractModuleDispatcher;
+
+defined("_JEXEC") or die;
+
+class Dispatcher extends AbstractModuleDispatcher
+{
+    protected function getLayoutData(): array
+    {
+        $data = parent::getLayoutData();
+        
+        return $data;
+    }
+}

--- a/modules/mod_github_portfolio/src/Helper/GithubPortfolioHelper.php
+++ b/modules/mod_github_portfolio/src/Helper/GithubPortfolioHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Joomla\Module\GithubPortfolio\Site\Helper;
+
+defined('_JEXEC') or die;
+
+class GithubPortfolioHelper
+{
+    public static function getUsername($params)
+    {
+        return $params->get('github_username', 'alikon');
+    }
+
+    public static function getMaxItems($params)
+    {
+        return (int) $params->get('max_items', 6);
+    }
+}

--- a/modules/mod_github_portfolio/tmpl/default.php
+++ b/modules/mod_github_portfolio/tmpl/default.php
@@ -3,14 +3,27 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Factory;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = $app->getDocument()->getWebAssetManager();
+$app = Factory::getApplication();
+$wa  = $app->getDocument()->getWebAssetManager();
+
+// Core JS if you still need it elsewhere
 $wa->useScript('core');
 
-$username = $params->get('github_username', 'alikon');
-$maxItems = (int) $params->get('max_items', 6);
-$moduleId = 'github-portfolio-' . $module->id;
+// Register & use dedicated JS asset
+$wa->registerAndUseScript(
+    'mod_github_portfolio.github-portfolio',
+    'modules/mod_github_portfolio/media/js/github-portfolio.js',
+    [],
+    ['defer' => true]
+);
+
+$username  = $params->get('github_username', 'alikon');
+$maxItems  = (int) $params->get('max_items', 6);
+$cacheTime = (int) $params->get('cache_time', 15) * 60000; // minutes -> ms
+$moduleId  = 'github-portfolio-' . (int) $module->id;
 ?>
 
 <div class="container py-5 mod-github-portfolio">
@@ -21,10 +34,17 @@ $moduleId = 'github-portfolio-' . $module->id;
         </div>
     </div>
 
-    <div class="row" id="<?php echo $moduleId; ?>">
+    <div
+        class="row"
+        id="<?php echo htmlspecialchars($moduleId, ENT_QUOTES, 'UTF-8'); ?>"
+        data-github-portfolio="1"
+        data-github-username="<?php echo htmlspecialchars($username, ENT_QUOTES, 'UTF-8'); ?>"
+        data-max-items="<?php echo (int) $maxItems; ?>"
+        data-cache-time="<?php echo (int) $cacheTime; ?>"
+    >
         <p class="text-center text-muted col-12">Loading GitHub Portfolio...</p>
     </div>
-    
+
     <div class="row text-center mt-4">
         <div class="col-12">
             <a href="https://github.com/<?php echo htmlspecialchars($username, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-lg">
@@ -33,97 +53,3 @@ $moduleId = 'github-portfolio-' . $module->id;
         </div>
     </div>
 </div>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const GITHUB_USERNAME = <?php echo json_encode($username); ?>;
-    const MAX_ITEMS = <?php echo $maxItems; ?>;
-    const CACHE_TIME = <?php echo (int) $params->get('cache_time', 15) * 60000; ?>;
-    const container = document.getElementById(<?php echo json_encode($moduleId); ?>);
-
-    if (!container) {
-        console.error("Error: Cannot find element with ID '" + <?php echo json_encode($moduleId); ?> + "'.");
-        return;
-    }
-
-    const cacheKey = 'github_' + GITHUB_USERNAME + '_' + MAX_ITEMS;
-    const cached = localStorage.getItem(cacheKey);
-    const cacheTime = localStorage.getItem(cacheKey + '_time');
-    
-    if (cached && cacheTime && (Date.now() - parseInt(cacheTime)) < CACHE_TIME) {
-        renderData(JSON.parse(cached));
-        return;
-    }
-
-    const apiUrl = `https://api.github.com/search/issues?q=author:${GITHUB_USERNAME}+type:pr&sort=updated&order=desc&per_page=${MAX_ITEMS}`;
-    
-    function formatDate(isoString) {
-        if (!isoString) return 'N/A';
-        const options = { year: 'numeric', month: 'short', day: 'numeric' };
-        return new Date(isoString).toLocaleDateString('en-US', options);
-    }
-
-    function renderData(data) {
-        const items = data.items || [];
-        let htmlOutput = '';
-        
-        items.forEach(pr => {
-            const repoUrl = pr.repository_url.replace('https://api.github.com/repos', 'https://github.com');
-            const repoName = pr.repository_url.split('/').pop();
-            const title = pr.title;
-            const link = pr.html_url;
-
-            let statusLabel = 'Under Review';
-            let dateText = `Last Updated: ${formatDate(pr.updated_at)}`;
-
-            if (pr.pull_request && pr.pull_request.merged_at) { 
-                statusLabel = 'Merged';
-                dateText = `Merged on: ${formatDate(pr.pull_request.merged_at)}`;
-            } else if (pr.draft === true) {
-                statusLabel = 'Draft';
-            } else if (pr.state === 'closed') {
-                statusLabel = 'Closed';
-                dateText = `Closed on: ${formatDate(pr.closed_at)}`;
-            }
-
-            htmlOutput += `
-                <div class="col-lg-4 col-md-6 col-sm-12 mb-4">
-                    <div class="p-4 rounded shadow h-100" style="background-color: #f8f9fa; border: 1px solid #dee2e6;">
-                        <h4>${title}</h4>
-                        <p class="small">
-                            <span style="font-weight: 600;">&#9679; Status: ${statusLabel}</span> 
-                        </p>
-                        <p class="small">
-                            <span>Repository:</span> 
-                            <a href="${repoUrl}" target="_blank">${repoName}</a>
-                        </p>
-                        <p class="small">
-                            <span class="fw-bold">${dateText}</span>
-                        </p>
-                        <a href="${link}" class="btn btn-primary btn-sm mt-3" target="_blank">
-                            View PR on GitHub &raquo;
-                        </a>
-                    </div>
-                </div>
-            `;
-        });
-
-        container.innerHTML = htmlOutput || '<p class="text-center text-muted col-12">No Pull Requests found.</p>';
-    }
-
-    fetch(apiUrl)
-        .then(response => {
-            if (!response.ok) throw new Error(`HTTP ${response.status}`);
-            return response.json();
-        })
-        .then(data => {
-            localStorage.setItem(cacheKey, JSON.stringify(data));
-            localStorage.setItem(cacheKey + '_time', Date.now().toString());
-            renderData(data);
-        })
-        .catch(error => {
-            console.error("Error fetching GitHub data:", error);
-            container.innerHTML = `<p class="text-center text-danger col-12">Unable to load Portfolio. API Error: ${error.message}.</p>`;
-        });
-});
-</script>

--- a/modules/mod_github_portfolio/tmpl/default.php
+++ b/modules/mod_github_portfolio/tmpl/default.php
@@ -1,0 +1,129 @@
+<?php
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\HTML\HTMLHelper;
+
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = $app->getDocument()->getWebAssetManager();
+$wa->useScript('core');
+
+$username = $params->get('github_username', 'alikon');
+$maxItems = (int) $params->get('max_items', 6);
+$moduleId = 'github-portfolio-' . $module->id;
+?>
+
+<div class="container py-5 mod-github-portfolio">
+    <div class="row text-center mb-5">
+        <div class="col-12">
+            <h2>My Recent GitHub Contributions</h2>
+            <p class="lead">Merged, Open and Draft Pull Requests.</p>
+        </div>
+    </div>
+
+    <div class="row" id="<?php echo $moduleId; ?>">
+        <p class="text-center text-muted col-12">Loading GitHub Portfolio...</p>
+    </div>
+    
+    <div class="row text-center mt-4">
+        <div class="col-12">
+            <a href="https://github.com/<?php echo htmlspecialchars($username, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary btn-lg">
+                Visit My GitHub Profile
+            </a>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const GITHUB_USERNAME = <?php echo json_encode($username); ?>;
+    const MAX_ITEMS = <?php echo $maxItems; ?>;
+    const CACHE_TIME = <?php echo (int) $params->get('cache_time', 15) * 60000; ?>;
+    const container = document.getElementById(<?php echo json_encode($moduleId); ?>);
+
+    if (!container) {
+        console.error("Error: Cannot find element with ID '" + <?php echo json_encode($moduleId); ?> + "'.");
+        return;
+    }
+
+    const cacheKey = 'github_' + GITHUB_USERNAME + '_' + MAX_ITEMS;
+    const cached = localStorage.getItem(cacheKey);
+    const cacheTime = localStorage.getItem(cacheKey + '_time');
+    
+    if (cached && cacheTime && (Date.now() - parseInt(cacheTime)) < CACHE_TIME) {
+        renderData(JSON.parse(cached));
+        return;
+    }
+
+    const apiUrl = `https://api.github.com/search/issues?q=author:${GITHUB_USERNAME}+type:pr&sort=updated&order=desc&per_page=${MAX_ITEMS}`;
+    
+    function formatDate(isoString) {
+        if (!isoString) return 'N/A';
+        const options = { year: 'numeric', month: 'short', day: 'numeric' };
+        return new Date(isoString).toLocaleDateString('en-US', options);
+    }
+
+    function renderData(data) {
+        const items = data.items || [];
+        let htmlOutput = '';
+        
+        items.forEach(pr => {
+            const repoUrl = pr.repository_url.replace('https://api.github.com/repos', 'https://github.com');
+            const repoName = pr.repository_url.split('/').pop();
+            const title = pr.title;
+            const link = pr.html_url;
+
+            let statusLabel = 'Under Review';
+            let dateText = `Last Updated: ${formatDate(pr.updated_at)}`;
+
+            if (pr.pull_request && pr.pull_request.merged_at) { 
+                statusLabel = 'Merged';
+                dateText = `Merged on: ${formatDate(pr.pull_request.merged_at)}`;
+            } else if (pr.draft === true) {
+                statusLabel = 'Draft';
+            } else if (pr.state === 'closed') {
+                statusLabel = 'Closed';
+                dateText = `Closed on: ${formatDate(pr.closed_at)}`;
+            }
+
+            htmlOutput += `
+                <div class="col-lg-4 col-md-6 col-sm-12 mb-4">
+                    <div class="p-4 rounded shadow h-100" style="background-color: #f8f9fa; border: 1px solid #dee2e6;">
+                        <h4>${title}</h4>
+                        <p class="small">
+                            <span style="font-weight: 600;">&#9679; Status: ${statusLabel}</span> 
+                        </p>
+                        <p class="small">
+                            <span>Repository:</span> 
+                            <a href="${repoUrl}" target="_blank">${repoName}</a>
+                        </p>
+                        <p class="small">
+                            <span class="fw-bold">${dateText}</span>
+                        </p>
+                        <a href="${link}" class="btn btn-primary btn-sm mt-3" target="_blank">
+                            View PR on GitHub &raquo;
+                        </a>
+                    </div>
+                </div>
+            `;
+        });
+
+        container.innerHTML = htmlOutput || '<p class="text-center text-muted col-12">No Pull Requests found.</p>';
+    }
+
+    fetch(apiUrl)
+        .then(response => {
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return response.json();
+        })
+        .then(data => {
+            localStorage.setItem(cacheKey, JSON.stringify(data));
+            localStorage.setItem(cacheKey + '_time', Date.now().toString());
+            renderData(data);
+        })
+        .catch(error => {
+            console.error("Error fetching GitHub data:", error);
+            container.innerHTML = `<p class="text-center text-danger col-12">Unable to load Portfolio. API Error: ${error.message}.</p>`;
+        });
+});
+</script>


### PR DESCRIPTION
Add github portfolio module

## Summary by Sourcery

Add a new Joomla site module that displays a GitHub portfolio of recent pull requests for a configured user.

New Features:
- Introduce a GitHub portfolio frontend module that lists a user’s recent pull requests with status and repository information.
- Add module configuration options for GitHub username, maximum items to display, and client-side cache duration.

Enhancements:
- Register the new module with a dedicated dispatcher, DI service provider, and helper class for parameter access.
- Add English language strings and XML metadata for the GitHub portfolio module’s title, description, and configuration fields.