### PR TITLE
Add mod_backward

### DIFF
--- a/modules/mod_backward/language/en-GB/mod_backward.ini
+++ b/modules/mod_backward/language/en-GB/mod_backward.ini
@@ -5,4 +5,4 @@
 
 MOD_BACKWARD="Joomla! Backward Compatibility Information"
 MOD_BACKWARD_TEXT="Backward: "
-MOD_BACKWARD_XML_DESCRIPTION="This module displays the which Joomla! Backward Compatibility plugins are enabled and is intended to be displayed in the 'status' position."
+MOD_BACKWARD_XML_DESCRIPTION="This module displays which Joomla! Backward Compatibility plugins are enabled and is intended to be displayed in the 'status' position."

--- a/modules/mod_backward/language/en-GB/mod_backward.ini
+++ b/modules/mod_backward/language/en-GB/mod_backward.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+MOD_BACKWARD="Joomla! Backward Compatibility Information"
+MOD_BACKWARD_TEXT="Backward: "
+MOD_BACKWARD_XML_DESCRIPTION="This module displays the which Joomla! Backward Compatibility plugins are enabled and is intended to be displayed in the 'status' position."

--- a/modules/mod_backward/language/en-GB/mod_backward.sys.ini
+++ b/modules/mod_backward/language/en-GB/mod_backward.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_BACKWARD="Joomla! Backward Compatibility Information"
-MOD_BACKWARD_XML_DESCRIPTION="This module displays the which Joomla! Backward Compatibility plugins are enabled and is intended to be displayed in the 'status' position."
+MOD_BACKWARD_XML_DESCRIPTION="This module displays which Joomla! Backward Compatibility plugins are enabled and is intended to be displayed in the 'status' position."

--- a/modules/mod_backward/language/en-GB/mod_backward.sys.ini
+++ b/modules/mod_backward/language/en-GB/mod_backward.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+MOD_BACKWARD="Joomla! Backward Compatibility Information"
+MOD_BACKWARD_XML_DESCRIPTION="This module displays the which Joomla! Backward Compatibility plugins are enabled and is intended to be displayed in the 'status' position."

--- a/modules/mod_backward/mod_backward.xml
+++ b/modules/mod_backward/mod_backward.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="module" client="administrator" method="upgrade">
+	<name>mod_backward</name>
+	<author>Joomla! Project</author>
+	<creationDate>2025-11</creationDate>
+	<copyright>(C) 2025 Open Source Matters, Inc.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>1.0.0</version>
+	<description>MOD_BACKWARD_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Module\Backward</namespace>
+	<files>
+		<folder module="mod_backward">services</folder>
+		<folder>src</folder>
+		<folder>tmpl</folder>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB/mod_backward.ini</language>
+		<language tag="en-GB">language/en-GB/mod_backward.sys.ini</language>
+	</languages>
+	<help key="Admin_Modules:_Joomla_Version_Information" />
+	<config>
+		<fields name="params">
+			<fieldset name="advanced">
+				<field
+					name="layout"
+					type="modulelayout"
+					label="JFIELD_ALT_LAYOUT_LABEL"
+					class="form-select"
+					validate="moduleLayout"
+				/>
+
+				<field
+					name="moduleclass_sfx"
+					type="textarea"
+					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
+					rows="3"
+					validate="CssIdentifier"
+				/>
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/modules/mod_backward/services/provider.php
+++ b/modules/mod_backward/services/provider.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  mod_backward
+ *
+ * @copyright   (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\Service\Provider\HelperFactory;
+use Joomla\CMS\Extension\Service\Provider\Module;
+use Joomla\CMS\Extension\Service\Provider\ModuleDispatcherFactory;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+return new class () implements ServiceProviderInterface {
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->registerServiceProvider(new ModuleDispatcherFactory('\\Joomla\\Module\\Backward'));
+        $container->registerServiceProvider(new HelperFactory('\\Joomla\\Module\\Backward\\Administrator\\Helper'));
+
+        $container->registerServiceProvider(new Module());
+    }
+};

--- a/modules/mod_backward/src/Dispatcher/Dispatcher.php
+++ b/modules/mod_backward/src/Dispatcher/Dispatcher.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  mod_backward
+ *
+ * @copyright   (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Module\Backward\Administrator\Dispatcher;
+
+use Joomla\CMS\Dispatcher\AbstractModuleDispatcher;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Version;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Dispatcher class for mod_backward
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Dispatcher extends AbstractModuleDispatcher
+{
+    /**
+     * Returns the layout data.
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getLayoutData()
+    {
+        $data               = parent::getLayoutData();
+        $data['compat']     = PluginHelper::isEnabled('behaviour', 'compat') ? (string) Version::MAJOR_VERSION : '';
+        $data['compatNext'] = PluginHelper::isEnabled('behaviour', 'compat6') ? (string) (Version::MAJOR_VERSION + 1) : '';
+
+        return $data;
+    }
+}

--- a/modules/mod_backward/tmpl/default.php
+++ b/modules/mod_backward/tmpl/default.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  mod_backward
+ *
+ * @copyright   (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+?>
+<?php if (!empty($compat) || !empty($compatNext)) : ?>
+    <div class="header-item-content joomlaversion">
+        <div class="header-item-text no-link">
+            <span class="icon-shield-alt" aria-hidden="true"></span>
+            <span aria-hidden="true"><?php echo Text::_('MOD_BACKWARD_TEXT') . $compat . ((!empty($compat) && !empty($compatNext)) ? ', ' : '') . $compatNext; ?></span>
+        </div>
+    </div>
+<?php endif; ?>


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new administrator status module that surfaces Joomla backward compatibility information based on enabled behaviour plugins.

New Features:
- Add the mod_backward administrator module to display backward compatibility status in the status position.
- Expose layout data indicating current and next major versions when relevant compatibility plugins are enabled.

Enhancements:
- Register the new module with the DI container using a service provider and dispatcher factory.
- Add English language strings and a default template for rendering backward compatibility information in the admin header.