### PR TITLE
adding mailpit to codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,15 +7,20 @@
         "ghcr.io/devcontainers/features/desktop-lite:1": {}
     },
     "portsAttributes": {
-        "80" : {
+        "443" : {
             "label": "Web Server (Joomla & phpmyadmin)",
             "onAutoForward": "silent"
         },
         "6080": {
             "label": "Cypress GUI",
             "onAutoForward": "silent"
+        },
+        "8025": {
+            "label": "Mailpit Web UI",
+            "onAutoForward": "openPreview"
         }
     },
+    "forwardPorts": [80, 443, 6080, 8025],
     "postCreateCommand": "bash ./.devcontainer/post-create.sh",
     "customizations": {
         "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./xdebug.ini:/usr/local/etc/php/conf.d/99-xdebug.ini
     ports:
       - "80:80"
+      - "443:443"
       - "3306:3306"
       - "6080:6080"
     command: sleep infinity
@@ -23,6 +24,10 @@ services:
       MYSQL_PASSWORD: joomla_ut
     volumes:
       - "mysql-data:/var/lib/mysql"
-
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "8025:8025"
 volumes:
   mysql-data:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -58,7 +58,12 @@ php installation/joomla.php install \
 # --- 5. Configure Joomla ---
 echo "--> Configuring Joomla..."
 php cli/joomla.php config:set debug=true error_reporting=maximum
-
+# Configure mail settings for Mailpit
+php cli/joomla.php config:set mailer=smtp
+php cli/joomla.php config:set smtphost=mailpit
+php cli/joomla.php config:set smtpport=1025
+php cli/joomla.php config:set smtpauth=0
+php cli/joomla.php config:set smtpsecure=none
 # Install extension if available
 ALIKONWEB_PKG="${WORKSPACE_ROOT}/dist/pkg-alikonweb-current.zip"
 if [ -f "$ALIKONWEB_PKG" ]; then
@@ -131,6 +136,10 @@ DETAILS_FILE="${WORKSPACE_ROOT}/codespace-details.txt"
     echo "  URL: Open the 'Web Server' port and add /phpmyadmin to the end."
     echo "  Username: joomla_ut"
     echo "  Password: joomla_ut"
+    echo ""
+    echo "Mailpit (Email Testing):"
+    echo "  URL: Open the 'Ports' tab, find 'Mailpit Web UI' (8025), and click the Globe icon"
+    echo "  All emails sent by Joomla will appear here for testing"
     echo ""
     echo "To use cypress testing:"
     echo "  Open 'Cypress GUI' port."

--- a/src/plugins/system/magiclogin/script.php
+++ b/src/plugins/system/magiclogin/script.php
@@ -239,8 +239,24 @@ return new class () implements ServiceProviderInterface {
 
                         }
                     } catch (\Exception $e) {
-                        Factory::getApplication()->enqueueMessage('Error creating #__noncore_extensions_safemode table: ' . $e->getMessage(), 'error');
+                        Factory::getApplication()->enqueueMessage('Error creating #__magiclogin_tokens table: ' . $e->getMessage(), 'error');
                     }
+
+                    $query->clear()
+                        ->insert($db->quoteName('#__mail_templates'))
+                        ->columns($db->quoteName(['template_id', 'extension', 'language', 'subject', 'body', 'htmlbody', 'attachments', 'params']))
+                        ->values(':templateid, :extension, :language, :subject, :body, :htmlbody, :attachments, :params')
+                        ->bind(':templateid', 'plg_system_magiclogin.magiclink')
+                        ->bind(':extension', 'plg_system_magiclogin')
+                        ->bind(':language', '')
+                        ->bind(':subject', 'PLG_SYSTEM_MAGICLOGIN_EMAIL_SUBJECT')
+                        ->bind(':body', 'PLG_SYSTEM_MAGICLOGIN_EMAIL_BODY')
+                        ->bind(':htmlbody', 'PLG_SYSTEM_MAGICLOGIN_EMAIL_HTMLBODY')
+                        ->bind(':attachments', '')
+                        ->bind(':params', '{"tags":["sitename","username","magic_link","expiry_minutes"]}');
+
+                    $db->setQuery($query);
+                    $db->execute();
                 }
 
                 /**


### PR DESCRIPTION
## Summary by Sourcery

Configure the development container to use Mailpit for SMTP email testing in Joomla within Codespaces.

New Features:
- Add a Mailpit service to the devcontainer Docker Compose setup for capturing outbound emails.
- Configure Joomla mail settings in the post-create script to send email through the Mailpit SMTP server.
- Document Mailpit access details in the Codespaces helper output for easier email testing.

Enhancements:
- Expose HTTPS port 443 from the Joomla web service in the devcontainer for secure access.