### PR TITLE
update extensions from cli console plugin

### DIFF
--- a/src/administrator/manifests/packages/pkg_alikonweb.xml
+++ b/src/administrator/manifests/packages/pkg_alikonweb.xml
@@ -18,6 +18,7 @@
         <file type="module" id="mod_jstats" client="site">mod_jstats.zip</file>
         <file type="module" id="mod_backward" client="admin">mod_backward.zip</file>
         <file type="module" id="mod_github_portfolio" client="site">mod_github_portfolio.zip</file>
+        <file type="plugin" id="updatefromcli" group="console">plg_console_updatefromcli.zip</file>
         <file type="plugin" id="safemode" group="console">plg_console_safemode.zip</file>
         <file type="plugin" id="magiclogin" group="system">plg_system_magiclogin.zip</file>
         <file type="plugin" id="safemode" group="system">plg_system_safemode.zip</file>

--- a/src/plugins/console/updatefromcli/services/provider.php
+++ b/src/plugins/console/updatefromcli/services/provider.php
@@ -11,20 +11,20 @@ use Joomla\Plugin\Console\Updatefromcli\Extension\UpdatefromcliConsolePlugin;
 
 return new class implements ServiceProviderInterface
 {
-    public function register(Container $container)
+    public function register(Container $container) : void
     {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
-                $dispatcher = $container->get(DispatcherInterface::class);
+                // Get plugin configuration from database
+                $config = (array) PluginHelper::getPlugin('console', 'updatefromcli');
 
-                $plugin = new UpdatefromcliConsolePlugin(
-                    $dispatcher,
-                    (array) PluginHelper::getPlugin('console', 'updatefromcli')
-                );
+                // Get event dispatcher for plugin events
+                $subject = $container->get(DispatcherInterface::class);
 
+                // Create plugin instance with dependencies
+                $plugin = new UpdatefromcliConsolePlugin($subject, $config);
                 $plugin->setApplication(Factory::getApplication());
-
                 return $plugin;
             }
         );

--- a/src/plugins/console/updatefromcli/services/provider.php
+++ b/src/plugins/console/updatefromcli/services/provider.php
@@ -1,0 +1,32 @@
+<?php
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\CMS\Factory;
+use Joomla\Plugin\Console\Updatefromcli\Extension\UpdatefromcliConsolePlugin;
+
+return new class implements ServiceProviderInterface
+{
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin = new UpdatefromcliConsolePlugin(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('console', 'updatefromcli')
+                );
+
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/src/plugins/console/updatefromcli/src/CliCommand/UpdatefromcliCommand.php
+++ b/src/plugins/console/updatefromcli/src/CliCommand/UpdatefromcliCommand.php
@@ -124,11 +124,11 @@ final class UpdatefromcliCommand extends AbstractCommand
      *
      * @since __DEPLOY_VERSION__
      */
-    protected function getExtensionInfo($extensions): array
+    protected function getExtensionInfo(array $extensions): array
     {
         $extInfo = [];
 
-        foreach ($extensions as $key => $extension) {
+        foreach ($extensions as $extension) {
             $extInfo[] = [
                 $extension->extension_id,
                 $extension->name,

--- a/src/plugins/console/updatefromcli/src/CliCommand/UpdatefromcliCommand.php
+++ b/src/plugins/console/updatefromcli/src/CliCommand/UpdatefromcliCommand.php
@@ -1,8 +1,6 @@
 <?php
 namespace Joomla\Plugin\Console\Updatefromcli\CliCommand;
 
-defined('_JEXEC') or die;
-
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Updater\Updater;
 use Joomla\Console\Command\AbstractCommand;

--- a/src/plugins/console/updatefromcli/src/CliCommand/UpdatefromcliCommand.php
+++ b/src/plugins/console/updatefromcli/src/CliCommand/UpdatefromcliCommand.php
@@ -1,0 +1,143 @@
+<?php
+namespace Joomla\Plugin\Console\Updatefromcli\CliCommand;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Updater\Updater;
+use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+/**
+ * Updatefromcli CLI Command
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class UpdatefromcliCommand extends AbstractCommand
+{
+    /**
+     * The default command name
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected static $defaultName = 'extension:update';
+
+    /**
+     * Internal function to execute the command.
+     *
+     * @param   InputInterface   $input   The input to inject into the command.
+     * @param   OutputInterface  $output  The output to inject into the command.
+     *
+     * @return  integer  The command exit code
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        $symfonyStyle = new SymfonyStyle($input, $output);
+
+        $symfonyStyle->title('Extension Updates');
+
+        if ($eid = $input->getOption('eid')) {
+            // Find updates.
+            /** @var UpdateModel $model */
+            $model = $this->getApplication()->bootComponent('com_installer')
+                ->getMVCFactory()->createModel('Update', 'Administrator', ['ignore_request' => true]);
+
+            // Purge the table before checking
+            $model->purge();
+            $model->findUpdates();
+            $extensions = $model->getItems();
+            $update     = [];
+
+            foreach ($extensions as $extension) {
+                if ($extension->extension_id === (int) $eid) {
+                    $update[] = $extension;
+                    break;
+                }
+            }
+
+            if (0 === \count($update)) {
+                $symfonyStyle->success('There are no available updates');
+                return Command::SUCCESS;
+            }
+
+            $symfonyStyle->note('There are available updates to apply');
+
+            $extensions = $this->getExtensionInfo($update);
+            $symfonyStyle->table(['Extension ID', 'Name', 'Location', 'Type', 'Installed','Available', 'Folder'], $extensions);
+
+            // Get the minimum stability.
+            $params            = ComponentHelper::getComponent('com_installer')->getParams();
+            $minimum_stability = (int) $params->get('minimum_stability', Updater::STABILITY_STABLE);
+            $model->update([$update[0]->update_id], $minimum_stability);
+
+            if ($model->getState('result')) {
+                $symfonyStyle->note($update[0]->name . ' has been updated to ' . $update[0]->version);
+
+                return Command::SUCCESS;
+            }
+
+            $symfonyStyle->error($update[0]->name . ' has not been updated to ' . $update[0]->version);
+
+            return Command::FAILURE;
+        }
+
+        $symfonyStyle->error('Invalid argument supplied for command.');
+
+        return Command::FAILURE;
+    }
+
+    /**
+     * Transforms extension arrays into required form
+     *
+     * @param   array  $extensions  Array of extensions
+     *
+     * @return array
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    protected function getExtensionInfo($extensions): array
+    {
+        $extInfo = [];
+
+        foreach ($extensions as $key => $extension) {
+            $extInfo[] = [
+                $extension->extension_id,
+                $extension->name,
+                $extension->client_translated,
+                $extension->type,
+                $extension->current_version,
+                $extension->version,
+                $extension->folder_translated,
+            ];
+        }
+
+        return $extInfo;
+    }
+
+    /**
+     * Configure the command.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function configure(): void
+    {
+        $this->addOption('eid', null, InputOption::VALUE_REQUIRED, 'The id of the extension');
+        $help = "<info>%command.name%</info> command perform extension updates
+		\nUsage: <info>php %command.full_name%</info>";
+
+        $this->setDescription('Perform extension updates');
+        $this->setHelp($help);
+    }
+}

--- a/src/plugins/console/updatefromcli/src/Extension/UpdatefromcliConsolePlugin.php
+++ b/src/plugins/console/updatefromcli/src/Extension/UpdatefromcliConsolePlugin.php
@@ -1,0 +1,28 @@
+<?php
+namespace Joomla\Plugin\Console\Updatefromcli\Extension;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Event\SubscriberInterface;
+use Joomla\Application\ApplicationEvents;
+use Joomla\Plugin\Console\Updatefromcli\CliCommand\UpdatefromcliCommand;
+
+class UpdatefromcliConsolePlugin extends CMSPlugin implements SubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Register commands BEFORE the CLI app executes
+            ApplicationEvents::BEFORE_EXECUTE => 'registerCommands',
+            //\Joomla\Application\ApplicationEvents::BEFORE_EXECUTE => 'registerCommands',
+        ];
+    }
+
+    public function registerCommands(): void
+    {
+        $this->getApplication()->addCommand(new UpdatefromcliCommand());
+        //$app = $this->getApplication();
+        //$app->addCommand(new UpdatefromcliCommand());
+    }
+}

--- a/src/plugins/console/updatefromcli/src/Extension/UpdatefromcliConsolePlugin.php
+++ b/src/plugins/console/updatefromcli/src/Extension/UpdatefromcliConsolePlugin.php
@@ -15,14 +15,12 @@ class UpdatefromcliConsolePlugin extends CMSPlugin implements SubscriberInterfac
         return [
             // Register commands BEFORE the CLI app executes
             ApplicationEvents::BEFORE_EXECUTE => 'registerCommands',
-            //\Joomla\Application\ApplicationEvents::BEFORE_EXECUTE => 'registerCommands',
         ];
     }
 
     public function registerCommands(): void
     {
         $this->getApplication()->addCommand(new UpdatefromcliCommand());
-        //$app = $this->getApplication();
-        //$app->addCommand(new UpdatefromcliCommand());
     }
 }
+

--- a/src/plugins/console/updatefromcli/updatefromcli.xml
+++ b/src/plugins/console/updatefromcli/updatefromcli.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="console" method="upgrade">
+    <name>PLG_CONSOLE_UPDATEFROMCLI</name>
+    <author>Alikon</author>
+    <creationDate>2026-01</creationDate>
+    <copyright>(C) 2007 Alikonweb</copyright>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <authorEmail>alikon@alikonweb.it</authorEmail>
+    <authorUrl>www.alikonweb.it</authorUrl>
+    <version>1.0.0</version>
+    <description>Console plugin for update extensions from CLI commands</description>
+
+    <!-- Correct namespace per Joomla docs -->
+    <namespace path="src">Joomla\Plugin\Console\Updatefromcli</namespace>
+
+    <files>
+        <!-- Services directory must be included -->
+        <folder plugin="updatefromcli">services</folder>
+        <!-- src directory for your plugin code -->
+        <folder>src</folder>
+    </files>
+</extension>
+
+


### PR DESCRIPTION
## Summary by Sourcery

Add a new console plugin that provides a CLI command for updating Joomla extensions by ID.

New Features:
- Introduce an `extension:update` CLI command to find and apply available updates for a specific extension ID.
- Register the new updatefromcli console plugin via a service provider and plugin manifest for use in the Joomla console application.