### PR TITLE
add task plugin test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,9 @@ jobs:
 
       - uses: ./.github/actions/setup-cypress
 
+      - name: Install sendmail
+        run: apt-get update && apt-get install -y sendmail
+
       - name: Setup and run ${{ matrix.db }}
         run: |
           ${{ matrix.alter-user-cmd }}

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -23,16 +23,17 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
       execution_rules: { 'rule-type': 'manual' },
       cron_rules: { type: 'manual', exp: '' },
       params: {
-        "articles":1,
-        "categories":1,
-        "components":["com_banners"],
-        "contacts":0,
-        "menus":0,
-        "modules":0,
-        "redirects":0,
-        "redirectspurge":0,
-        "tags":0,
-        "tasks":0
+         notifications: { success_mail: 1 },
+         articles:1,
+         categories:1,
+         components:["com_banners"],
+         contacts:0,
+         menus:0,
+         modules:0,
+         redirects:0,
+         redirectspurge":0,
+         tags:0,
+         tasks:0
       },
     }).then((task) => {
       cy.visit('/administrator/index.php?option=com_scheduler&view=tasks&filter=');

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -2,6 +2,7 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
 
   beforeEach(() => {
     // 1. Login to the Joomla Backend
+    cy.task('clearEmails');
     cy.doAdministratorLogin();
     cy.db_enableExtension('1', 'plg_task_deltrash');
   });
@@ -12,8 +13,8 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
     cy.get('div.new-task-details').contains('Delete trashed items').click();
     cy.title().should('contain', 'New Task');
     cy.get('h1.page-title').should('contain', 'New Task');
-    cy.get('#myTab div[role="tablist"] button[aria-controls="advanced"]').click();
-    cy.get('#task-form').contains('Delete trashed items').should('be.visible');
+    // Verify the plugin header is visible on the General tab
+    cy.get('#general').contains('Delete trashed items').should('be.visible')
   });
 
   it('can notify successful task execution', () => {

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -1,0 +1,38 @@
+describe('Joomla Task Plugin: Deltrash Test', () => {
+  const adminUrl = '/administrator';
+  const username = 'admin'; // Use env variables in production
+  const password = 'password';
+
+  beforeEach(() => {
+    // 1. Login to the Joomla Backend
+    cy.visit(adminUrl);
+    cy.get('#mod-login-username').type(username);
+    cy.get('#mod-login-password').type(password);
+    cy.get('.btn-primary.w-100').click();
+    
+    // Ensure we are logged in
+    cy.location('pathname').should('include', '/administrator/index.php');
+  });
+
+  it('should empty the trash using the deltrash task', () => {
+    // 2. Create dummy content and move it to trash
+    // (Or navigate to Articles and trash an existing one)
+    cy.visit(`${adminUrl}/index.php?option=com_content&view=articles`);
+    cy.get('#cb0').click(); // Select the first article
+    cy.get('.button-trash').click(); // Move to trash
+    
+    // 3. Navigate to Scheduled Tasks
+    cy.visit(`${adminUrl}/index.php?option=com_scheduler&view=tasks`);
+
+    // 4. Find the 'deltrash' task and run it
+    // Note: This assumes you have already created a task instance for this plugin
+    cy.contains('deltrash').parents('tr').find('.js-scheduler-run-task').click();
+
+    // 5. Verify the success message
+    cy.get('.alert-message').should('contain', 'Task successfully executed');
+
+    // 6. Final check: Go to the Trash view and ensure it is empty
+    cy.visit(`${adminUrl}/index.php?option=com_content&view=articles&filter[published]=-2`);
+    cy.get('.no-results-message').should('exist');
+  });
+});

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -31,7 +31,7 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
          menus:0,
          modules:0,
          redirects:0,
-         redirectspurge":0,
+         redirectspurge:0,
          tags:0,
          tasks:0
       },

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -73,7 +73,7 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
     cy.get('.alert-message').should('contain', 'Task successfully executed');
 
     // 6. Final check: Go to the Trash view and ensure it is empty
-    cy.visit('/administrator/index.php?option=com_content&view=articles&filter=[published]=-2`);
+    cy.visit('/administrator/index.php?option=com_content&view=articles&filter=[published]=-2');
     cy.get('.no-results-message').should('exist');
   });
 

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -1,28 +1,69 @@
 describe('Joomla Task Plugin: Deltrash Test', () => {
-  const adminUrl = '/administrator';
-  const username = 'admin'; // Use env variables in production
-  const password = 'password';
 
   beforeEach(() => {
     // 1. Login to the Joomla Backend
-    cy.visit(adminUrl);
-    cy.get('#mod-login-username').type(username);
-    cy.get('#mod-login-password').type(password);
-    cy.get('.btn-primary.w-100').click();
-    
-    // Ensure we are logged in
-    cy.location('pathname').should('include', '/administrator/index.php');
+    cy.doAdministratorLogin();
+    cy.db_enableExtension('1', 'plg_task_deltrash');
   });
 
+  it('can display notification form', () => {
+    cy.visit('/administrator/index.php?option=com_scheduler&view=tasks');
+    cy.clickToolbarButton('New');
+    cy.get('div.new-task-details').contains('Delete trashed items').click();
+    cy.title().should('contain', 'New Task');
+    cy.get('h1.page-title').should('contain', 'New Task');
+    cy.get('#myTab div[role="tablist"] button[aria-controls="advanced"]').click();
+    cy.get('#task-form').contains('Delete trashed items').should('be.visible');
+  });
+
+  it('can notify successful task execution', () => {
+    cy.db_createSchedulerTask({
+      title: 'Test task',
+      type: 'plg_task_deltrash',
+      execution_rules: { 'rule-type': 'manual' },
+      cron_rules: { type: 'manual', exp: '' },
+      params: {
+        "articles":1,
+        "categories":1,
+        "components":["com_banners"],
+        "contacts":0,
+        "menus":0,
+        "modules":0,
+        "redirects":0,
+        "redirectspurge":0,
+        "tags":0,
+        "tasks":0
+      },
+    }).then((task) => {
+      cy.visit('/administrator/index.php?option=com_scheduler&view=tasks&filter=');
+      cy.searchForItem('Test task');
+      cy.intercept('GET', '**/administrator/index.php?option=com_ajax&format=json&plugin=RunSchedulerTest&group=system&id=*').as('runschedulertest');
+      cy.get('button[data-scheduler-run]').should('have.attr', 'data-id', task.id).click();
+      cy.wait('@runschedulertest').then((interception) => {
+        expect(interception.response.body.message).to.eq(null);
+        expect(interception.response.body.success).to.eq(true);
+      });
+      cy.get('joomla-dialog[type="inline"]').should('be.visible');
+      cy.get('joomla-dialog[type="inline"]').within(() => {
+        cy.get('header.joomla-dialog-header').should('contain', `Test task (ID: ${task.id})`);
+        cy.get('div.scheduler-status').should('contain', 'Status: Completed');
+      });
+      cy.task('getMails').then((mails) => {
+        cy.wrap(mails).should('have.lengthOf', 1);
+        cy.wrap(mails[0].body).should('have.string', `Scheduled Task#${task.id}, Test task, has been successfully executed`);
+        cy.wrap(mails[0].headers.subject).should('have.string', 'Task Successful');
+        cy.wrap(mails[0].headers.from).should('equal', `"${Cypress.env('sitename')}" <${Cypress.env('email')}>`);
+        cy.wrap(mails[0].headers.to).should('equal', Cypress.env('email'));
+      });
+    });
+  });
+  
   it('should empty the trash using the deltrash task', () => {
     // 2. Create dummy content and move it to trash
-    // (Or navigate to Articles and trash an existing one)
-    cy.visit(`${adminUrl}/index.php?option=com_content&view=articles`);
-    cy.get('#cb0').click(); // Select the first article
-    cy.get('.button-trash').click(); // Move to trash
+    trashDummyArticle();// Move to trash
     
     // 3. Navigate to Scheduled Tasks
-    cy.visit(`${adminUrl}/index.php?option=com_scheduler&view=tasks`);
+    cy.visit('/administrator/index.php?option=com_scheduler&view=tasks');
 
     // 4. Find the 'deltrash' task and run it
     // Note: This assumes you have already created a task instance for this plugin
@@ -32,7 +73,20 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
     cy.get('.alert-message').should('contain', 'Task successfully executed');
 
     // 6. Final check: Go to the Trash view and ensure it is empty
-    cy.visit(`${adminUrl}/index.php?option=com_content&view=articles&filter[published]=-2`);
+    cy.visit('/administrator/index.php?option=com_content&view=articles&filter=[published]=-2`);
     cy.get('.no-results-message').should('exist');
   });
+
+  // Helper function to ensure we have a trashed item
+  function trashDummyArticle() {
+    cy.db_createArticle({ title: 'Test trash article' }).then(() => {
+      cy.reload();
+      cy.searchForItem('Test trash article');
+      cy.checkAllResults();
+      cy.clickToolbarButton('Action');
+      cy.contains('Trash').click();
+
+      cy.checkForSystemMessage('Article trashed.');
+    });
+  }
 });

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -7,7 +7,7 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
     cy.db_enableExtension('1', 'plg_task_deltrash');
   });
 
-  it('can display notification form', () => {
+  it('can display the plugin form', () => {
     cy.visit('/administrator/index.php?option=com_scheduler&view=tasks');
     cy.clickToolbarButton('New');
     cy.get('div.new-task-details').contains('Delete trashed items').click();
@@ -36,7 +36,7 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
       execution_rules: { 'rule-type': 'manual' },
       cron_rules: { type: 'manual', exp: '' },
       params: {
-         notifications: { success_mail: 1 },
+         notifications: { success_mail: 0 },
          articles:1,
          categories:1,
          components:["com_banners"],

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -17,7 +17,19 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
     cy.get('#general').contains('Delete trashed items').should('be.visible')
   });
 
-  it('can notify successful task execution', () => {
+  it('should empty the trash using the deltrash task', () => {
+    // Create dummy content and move it to trash
+    cy.db_createArticle({ title: 'Test trash article' }).then(() => {
+      cy.reload();
+      cy.visit('/administrator/index.php?option=com_content&view=articles&filter=');
+      cy.searchForItem('Test trash article');
+      cy.checkAllResults();
+      cy.clickToolbarButton('Action');
+      cy.contains('Trash').click();
+
+      cy.checkForSystemMessage('Article trashed.');
+    });
+    
     cy.db_createSchedulerTask({
       title: 'Test task',
       type: 'plg_task_deltrash',
@@ -47,48 +59,16 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
       });
       cy.get('joomla-dialog[type="inline"]').should('be.visible');
       cy.get('joomla-dialog[type="inline"]').within(() => {
-        cy.get('header.joomla-dialog-header').should('contain', `Test task (ID: ${task.id})`);
+      //  cy.get('header.joomla-dialog-header').should('contain', `Run task (ID: ${task.id})`);
         cy.get('div.scheduler-status').should('contain', 'Status: Completed');
       });
-      cy.task('getMails').then((mails) => {
-        cy.wrap(mails).should('have.lengthOf', 1);
-        cy.wrap(mails[0].body).should('have.string', `Scheduled Task#${task.id}, Test task, has been successfully executed`);
-        cy.wrap(mails[0].headers.subject).should('have.string', 'Task Successful');
-        cy.wrap(mails[0].headers.from).should('equal', `"${Cypress.env('sitename')}" <${Cypress.env('email')}>`);
-        cy.wrap(mails[0].headers.to).should('equal', Cypress.env('email'));
-      });
+
     });
-  });
-  
-  it('should empty the trash using the deltrash task', () => {
-    // 2. Create dummy content and move it to trash
-    trashDummyArticle();// Move to trash
-    
-    // 3. Navigate to Scheduled Tasks
-    cy.visit('/administrator/index.php?option=com_scheduler&view=tasks');
 
-    // 4. Find the 'deltrash' task and run it
-    // Note: This assumes you have already created a task instance for this plugin
-    cy.contains('deltrash').parents('tr').find('.js-scheduler-run-task').click();
-
-    // 5. Verify the success message
-    cy.get('.alert-message').should('contain', 'Task successfully executed');
-
-    // 6. Final check: Go to the Trash view and ensure it is empty
+    // Final check: Go to the Trash view and ensure it is empty
     cy.visit('/administrator/index.php?option=com_content&view=articles&filter=[published]=-2');
-    cy.get('.no-results-message').should('exist');
+    cy.get('.display-5').should('exist');
+    cy.get('.display-5').should('contain', 'No Articles have been created yet');
+    
   });
-
-  // Helper function to ensure we have a trashed item
-  function trashDummyArticle() {
-    cy.db_createArticle({ title: 'Test trash article' }).then(() => {
-      cy.reload();
-      cy.searchForItem('Test trash article');
-      cy.checkAllResults();
-      cy.clickToolbarButton('Action');
-      cy.contains('Trash').click();
-
-      cy.checkForSystemMessage('Article trashed.');
-    });
-  }
 });

--- a/tests/cypress/support/commands/db.mjs
+++ b/tests/cypress/support/commands/db.mjs
@@ -705,4 +705,39 @@ Cypress.Commands.add('db_createWeblink', (weblinkData) => {
 
       return weblink;
     });
+  
+});
+
+/**
+ * Creates a scheduler task in the database with the given data. The task contains some default values when
+ * not all required fields are passed in the given data. The data of the inserted task is returned.
+ *
+ * @param {Object} taskData The task data to insert
+ *
+ * @returns Object
+ */
+Cypress.Commands.add('db_createSchedulerTask', (taskData) => {
+  const defaultTaskOptions = {
+    title: 'test task',
+    type: '',
+    execution_rules: {},
+    cron_rules: {},
+    state: 1,
+    params: {},
+    note: '',
+    created: '2023-01-01 20:00:00',
+  };
+  const task = { ...defaultTaskOptions, ...taskData };
+  ['execution_rules', 'cron_rules', 'params'].forEach((key) => {
+    if (typeof task[key] === 'object') {
+      task[key] = JSON.stringify(task[key]);
+    }
+  });
+
+  return cy.task('queryDB', createInsertQuery('scheduler_tasks', task))
+    .then(async (info) => {
+      task.id = info.insertId;
+
+      return task;
+    });
 });


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add a Cypress integration test that logs into the Joomla backend, trashes an article, runs the deltrash scheduled task, and asserts the trash is emptied and a success message is shown.