### PR TITLE
add php 8.5 to ci/cd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         joomla-version: ['5.4', '6.0', '6.1']
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
         db: [mysql, mariadb, pgsql]
         include:
           - db: mysql
@@ -212,7 +212,7 @@ jobs:
             image: mariadb:10.6
         exclude:
           - joomla-version: '5.4'
-            php-version: '8.4'
+            php-version: '8.5'
           - joomla-version: '6.0'
             php-version: '8.2'
           - joomla-version: '6.1'


### PR DESCRIPTION
## Summary by Sourcery

Add PHP 8.5 coverage to the CI test matrix while updating version exclusions accordingly.

CI:
- Extend the CI matrix to run tests on PHP 8.5 across supported Joomla versions.
- Adjust Joomla/PHP exclusion rules in the CI workflow to match the new PHP 8.5 entry.