### PR TITLE
Add mod_jstats test

### DIFF
--- a/cypress.config.dist.js
+++ b/cypress.config.dist.js
@@ -18,6 +18,7 @@ export default defineConfig({
       'tests/cypress/integration/site/**/*.cy.{js,jsx,ts,tsx}',
       'tests/cypress/integration/api/**/*.cy.{js,jsx,ts,tsx}',
       'tests/cypress/integration/plugins/**/*.cy.{js,jsx,ts,tsx}',
+      'tests/cypress/integration/modules/**/*.cy.{js,jsx,ts,tsx}',      
     ],
     supportFile: 'tests/cypress/support/index.js',
     scrollBehavior: 'center',

--- a/tests/cypress/integration/modules/mod_github_portfolio.cy.js
+++ b/tests/cypress/integration/modules/mod_github_portfolio.cy.js
@@ -1,0 +1,9 @@
+describe('Test in frontend that the Jstats', () => {
+  it('can display Github Portfolio', () => {
+    cy.db_createModule({ title: 'Github Portfolio', module: 'mod_github_portfolio' })
+      .then(() => {
+        cy.visit('/');
+        cy.contains('Github Portfolio');
+      });
+  });
+});

--- a/tests/cypress/integration/modules/mod_jstats.cy.js
+++ b/tests/cypress/integration/modules/mod_jstats.cy.js
@@ -1,6 +1,6 @@
 describe('Test in frontend that the Jstats', () => {
   it('can display joomla statistics', () => {
-    cy.db_createModule({ title: 'Joomla! Statistics', module: 'mod_jstats' }))
+    cy.db_createModule({ title: 'Joomla! Statistics', module: 'mod_jstats' })
       .then(() => {
         cy.visit('/');
         cy.contains('Joomla! Statistics');

--- a/tests/cypress/integration/modules/mod_jstats.cy.js
+++ b/tests/cypress/integration/modules/mod_jstats.cy.js
@@ -1,0 +1,9 @@
+describe('Test in frontend that the Jstats', () => {
+  it('can display joomla statistics', () => {
+    cy.db_createModule({ title: 'Joomla! Statistics', module: 'mod_jstats' }))
+      .then(() => {
+        cy.visit('/');
+        cy.contains('Joomla! Statistics');
+      });
+  });
+});


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add a Cypress test to verify that the mod_jstats module renders the 'Joomla! Statistics' text on the frontend.