### PR TITLE
add delay

### DIFF
--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -9,7 +9,8 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
 
   it('can display the plugin form', () => {
     cy.visit('/administrator/index.php?option=com_scheduler&view=tasks');
-    cy.wait(1000).clickToolbarButton('New');
+    cy.get('#toolbar-new', { timeout: 10000 }).should('be.visible');
+    cy.clickToolbarButton('New');
     cy.get('div.new-task-details').contains('Delete trashed items').click();
     cy.title().should('contain', 'New Task');
     cy.get('h1.page-title').should('contain', 'New Task');

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -9,7 +9,7 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
 
   it('can display the plugin form', () => {
     cy.visit('/administrator/index.php?option=com_scheduler&view=tasks');
-    cy.clickToolbarButton('New');
+    cy.wait(1000).clickToolbarButton('New');
     cy.get('div.new-task-details').contains('Delete trashed items').click();
     cy.title().should('contain', 'New Task');
     cy.get('h1.page-title').should('contain', 'New Task');

--- a/tests/cypress/integration/plugins/deltrash.cy.js
+++ b/tests/cypress/integration/plugins/deltrash.cy.js
@@ -9,7 +9,7 @@ describe('Joomla Task Plugin: Deltrash Test', () => {
 
   it('can display the plugin form', () => {
     cy.visit('/administrator/index.php?option=com_scheduler&view=tasks');
-    cy.get('#toolbar-new', { timeout: 10000 }).should('be.visible');
+    cy.get('#toolbar-new', { timeout: 40000 }).should('be.visible');
     cy.clickToolbarButton('New');
     cy.get('div.new-task-details').contains('Delete trashed items').click();
     cy.title().should('contain', 'New Task');


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Introduce an explicit wait before clicking the toolbar "New" button in the Deltrash plugin Cypress test.