### PR TITLE
Enhance error message with URL in changelog template

### DIFF
--- a/src/modules/mod_changelog/changelog.xml
+++ b/src/modules/mod_changelog/changelog.xml
@@ -1,0 +1,35 @@
+<changelogs>
+    <changelog>
+        <element>mod_changelog</element>
+        <type>module</type>
+        <version>1.0.0</version>
+        <security>
+            <item>Item A</item>
+            <item>Item b</item>
+        </security>
+        <fix>
+            <item>Item A</item>
+            <item>Item b</item>
+        </fix>
+        <language>
+            <item>Item A</item>
+            <item>Item b</item>
+        </language>
+        <addition>
+            <item>Item A</item>
+            <item>Item b</item>
+        </addition>
+        <change>
+            <item>Item A</item>
+            <item>Item b</item>
+        </change>
+        <remove>
+            <item>Item A</item>
+            <item>Item b</item>
+        </remove>
+        <note>
+            <item>Item A</item>
+            <item>Item b</item>
+        </note>
+    </changelog>
+</changelogs>

--- a/src/modules/mod_changelog/src/Dispatcher/Dispatcher.php
+++ b/src/modules/mod_changelog/src/Dispatcher/Dispatcher.php
@@ -23,6 +23,7 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
         $helper = $this->getHelperFactory()->getHelper('ChangelogHelper');
         // Fetch the data
         $data['list'] = $helper->getChangelogData($githubUrl);
+        $data['url']  = $githubUrl;
 
         return $data;
     }

--- a/src/modules/mod_changelog/tmpl/default.php
+++ b/src/modules/mod_changelog/tmpl/default.php
@@ -6,7 +6,7 @@
     <h3 class="mb-4 border-bottom pb-2">Project Updates</h3>
     
     <?php if (!$list || empty($list)): ?>
-        <div class="alert alert-warning">Unable to load changelog from GitHub <?php echo htmlspecialchars($url); ?></div>
+        <div class="alert alert-warning">Unable to load changelog from GitHub <?php echo htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></div>
     <?php else: ?>
         <div class="list-group list-group-flush">
             <?php foreach ($list as $item): ?>

--- a/src/modules/mod_changelog/tmpl/default.php
+++ b/src/modules/mod_changelog/tmpl/default.php
@@ -6,7 +6,7 @@
     <h3 class="mb-4 border-bottom pb-2">Project Updates</h3>
     
     <?php if (!$list || empty($list)): ?>
-        <div class="alert alert-warning">Unable to load changelog from GitHub.</div>
+        <div class="alert alert-warning">Unable to load changelog from GitHub <?php echo htmlspecialchars($url); ?></div>
     <?php else: ?>
         <div class="list-group list-group-flush">
             <?php foreach ($list as $item): ?>

--- a/src/modules/mod_changelog/updateserver.xml
+++ b/src/modules/mod_changelog/updateserver.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<updates>
+    <update>
+        <name>Module - Changelog</name>
+        <description>Joomla! Module - Cheagelog</description>
+        <element>mod_changelog</element>
+        <type>module</type>
+        <version>1.0.0</version>
+        <client>site</client>
+        <php_minimum>8.1</php_minimum>
+        <infourl title="Joomla! Module - Changelog">https://www.alikonweb.it</infourl>
+        <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/modules/mod_github_portfolio/changelog.xml</changelogurl>
+        <downloads>
+            <downloadurl type="full" format="zip">https://raw.githubusercontent.com/alikon/testcom/main/src/modules/mod_changelog/mod_changelog-1.0.0.zip</downloadurl>
+        </downloads>
+        <tags><tag>stable</tag></tags>
+        <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>
+        <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
+    </update>
+</updates>

--- a/src/modules/mod_jstats/changelog.xml
+++ b/src/modules/mod_jstats/changelog.xml
@@ -32,4 +32,12 @@
             <item>Item b</item>
         </note>
     </changelog>
+    <changelog>
+        <element>mod_jstats</element>
+        <type>module</type>
+        <version>1.1.0</version>
+        <addition>
+            <item>Javascript refactor</item>
+        </addition>        
+    </changelog>
 </changelogs>

--- a/src/modules/mod_jstats/mod_jstats.xml
+++ b/src/modules/mod_jstats/mod_jstats.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>alikon@alikonweb.it</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<description>MOD_JSTATS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\Jstats</namespace>
 	<media destination="mod_jstats" folder="media">

--- a/src/modules/mod_jstats/updateserver.xml
+++ b/src/modules/mod_jstats/updateserver.xml
@@ -17,4 +17,21 @@
         <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>
         <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
     </update>
+    <update>
+        <name>Module - Joomla Statistics</name>
+        <description>Joomla! Module - Joomla Statistics</description>
+        <element>mod_jstats</element>
+        <type>module</type>
+        <version>1.1.0</version>
+        <client>site</client>
+        <php_minimum>8.1</php_minimum>
+        <infourl title="Joomla! Module - Joomla Statistics">https://www.alikonweb.it</infourl>
+        <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/modules/mod_jstats/changelog.xml</changelogurl>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2/mod_jstats-1.1.0.zip</downloadurl>
+        </downloads>
+        <tags><tag>stable</tag></tags>
+        <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>
+        <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
+    </update>
 </updates>

--- a/src/plugins/console/safemode/changelog.xml
+++ b/src/plugins/console/safemode/changelog.xml
@@ -15,4 +15,13 @@
             <item>Not listed on Joomla Extension Directory</item>
         </note>
     </changelog>
+    <changelog>
+        <element>safemode</element>
+        <folder>console</folder>
+        <type>plugin</type>
+        <version>1.0.1</version>
+        <language>
+            <item>CLI language support</item>
+        </language>
+    </changelog>
 </changelogs>

--- a/src/plugins/console/safemode/safemode.xml
+++ b/src/plugins/console/safemode/safemode.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>alikon@alikonweb.it</authorEmail>
     <authorUrl>www.alikonweb.it</authorUrl>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>PLG_CONSOLE_SAFEMODE_XML_DESCRIPTION</description>
 
     <!-- Correct namespace per Joomla docs -->

--- a/src/plugins/console/safemode/updateserver.xml
+++ b/src/plugins/console/safemode/updateserver.xml
@@ -18,4 +18,22 @@
         <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>
         <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
     </update>
+    <update>
+        <name>Console - SafeMode</name>
+        <description>Joomla! Console - SafeMode Plugin</description>
+        <element>safemode</element>
+        <type>plugin</type>
+        <folder>console</folder>
+        <version>1.0.1</version>
+        <client>site</client>
+        <php_minimum>8.1</php_minimum>
+        <infourl title="Joomla! Console - SafeMode Plugin">https://www.alikonweb.it/extensions/console-plugin-safemode</infourl>
+        <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/console/safemode/changelog.xml</changelogurl>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2/plg_console_safemode-1.0.1.zip</downloadurl>
+        </downloads>
+        <tags><tag>stable</tag></tags>
+        <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>
+        <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
+    </update>
 </updates>

--- a/src/plugins/content/export/changelog.xml
+++ b/src/plugins/content/export/changelog.xml
@@ -81,4 +81,13 @@
             <item>Ready for Jooomla 5/6</item>
         </note>
     </changelog>
+    <changelog>
+        <element>export</element>
+        <folder>content</folder>
+        <type>plugin</type>
+        <version>2.1.1</version>
+        <addition>
+            <item>Version info</item>
+        </addition>
+    </changelog>
 </changelogs>

--- a/src/plugins/content/export/export.xml
+++ b/src/plugins/content/export/export.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>alikon@alikonweb.it</authorEmail>
 	<authorUrl>www.alikonweb.it</authorUrl>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 	<description>PLG_CONTENT_EXPORT_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Content\Export</namespace>
 	<changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/content/export/changelog.xml</changelogurl>

--- a/src/plugins/content/export/updateserver.xml
+++ b/src/plugins/content/export/updateserver.xml
@@ -110,7 +110,7 @@
         <updatefromcli>false</updatefromcli>
         <targetplatform name="joomla" version="((4\.[01234])|(5\.[01234]))" />
     </update>
-        <update>
+    <update>
         <name>Content - Export Article</name>
         <description>Joomla! Content - Export Article Plugin</description>
         <element>export</element>
@@ -123,6 +123,25 @@
         <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/content/export/changelog.xml</changelogurl>
         <downloads>
             <downloadurl type="full" format="zip">https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/content/export/plg_content_export-2.1.0.zip</downloadurl>
+        </downloads>
+        <tags><tag>stable</tag></tags>
+        <sha256>62fc64675d080cfff6232fd96e30606df18b7a3fc70c89af254bbfaf55997858</sha256>
+        <updatefromcli>false</updatefromcli>
+        <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
+    </update>
+    <update>
+        <name>Content - Export Article</name>
+        <description>Joomla! Content - Export Article Plugin</description>
+        <element>export</element>
+        <type>plugin</type>
+        <folder>content</folder>
+        <version>2.1.1</version>
+        <client>site</client>
+        <php_minimum>8.1</php_minimum>
+        <infourl title="Joomla! Content - Export Article Plugin">https://www.alikonweb.it/extensions/content-plugin-export-article</infourl>
+        <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/content/export/changelog.xml</changelogurl>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2/plg_content_export-2.1.0.zip</downloadurl>
         </downloads>
         <tags><tag>stable</tag></tags>
         <sha256>62fc64675d080cfff6232fd96e30606df18b7a3fc70c89af254bbfaf55997858</sha256>

--- a/src/plugins/content/swaggerui/changelog.xml
+++ b/src/plugins/content/swaggerui/changelog.xml
@@ -22,8 +22,6 @@
         <version>2.0.0</version>
         <addition>
             <item>Added support for CDN assets</item>
-        </addition>
-        <addition>
             <item>Use Web Asset Manager</item>
         </addition>
     </changelog>

--- a/src/plugins/content/swaggerui/updateserver.xml
+++ b/src/plugins/content/swaggerui/updateserver.xml
@@ -18,7 +18,7 @@
         <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>
         <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
     </update>
-        <update>
+    <update>
         <name>Content - SwaggerUI</name>
         <description>Joomla! Content - SwaggerUI Plugin</description>
         <element>swaggerui</element>
@@ -30,7 +30,7 @@
         <infourl title="Joomla! Content - SwaggerUI Plugin">https://www.alikonweb.it/extensions/content-plugin-swaggerui</infourl>
         <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/content/swaggerui/changelog.xml</changelogurl>
         <downloads>
-            <downloadurl type="full" format="zip">https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/content/swaggerui/plg_content_swaggerui-2.0.0.zip</downloadurl>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2/plg_content_swaggerui-2.0.0.zip</downloadurl>
         </downloads>
         <tags><tag>stable</tag></tags>
         <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>

--- a/src/plugins/system/magiclogin/updateserver.xml
+++ b/src/plugins/system/magiclogin/updateserver.xml
@@ -12,7 +12,7 @@
         <infourl title="Joomla! System - MagicLogin Plugin">https://www.alikonweb.it/extensions/system-plugin-magiclogin</infourl>
         <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/system/magiclogin/changelog.xml</changelogurl>
         <downloads>
-            <downloadurl type="full" format="zip">https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/system/magiclogin/plg_system_magiclogin-1.0.0.zip</downloadurl>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2/plg_system_magiclogin-1.0.0.zip</downloadurl>
         </downloads>
         <tags><tag>stable</tag></tags>
         <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>

--- a/src/plugins/system/safemode/updateserver.xml
+++ b/src/plugins/system/safemode/updateserver.xml
@@ -12,7 +12,7 @@
         <infourl title="Joomla! System - SafeMode Plugin">https://www.alikonweb.it/extensions/system-plugin-safemode</infourl>
         <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/system/safemode/changelog.xml</changelogurl>
         <downloads>
-            <downloadurl type="full" format="zip">https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/system/safemode/plg_system_safemode-1.0.0.zip</downloadurl>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2/plg_system_safemode-1.0.0.zip</downloadurl>
         </downloads>
         <tags><tag>stable</tag></tags>
         <sha256>9aed8c950a73b86a38f19cc4629dd71ace35fdcc62215a41902bbea16d3c4b9d</sha256>

--- a/src/plugins/task/deltrash/changelog.xml
+++ b/src/plugins/task/deltrash/changelog.xml
@@ -106,4 +106,13 @@
             <item>Ready for Jooomla 5/6</item>
         </note>
     </changelog>
+    <changelog>
+        <element>deltrash</element>
+        <folder>task</folder>
+        <type>plugin</type>
+        <version>1.7.2</version>
+        <note>
+            <item>CLI language support</item>
+        </note>
+    </changelog>
 </changelogs>

--- a/src/plugins/task/deltrash/deltrash.xml
+++ b/src/plugins/task/deltrash/deltrash.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>alikon@alikonweb.it</authorEmail>
 	<authorUrl>www.alikonweb.it</authorUrl>
-	<version>1.7.1</version>
+	<version>1.7.2</version>
 	<description>PLG_TASK_DELTRASH_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Task\Deltrash</namespace>
 	<changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/task/deltrash/changelog.xml</changelogurl>

--- a/src/plugins/task/deltrash/updateserver.xml
+++ b/src/plugins/task/deltrash/updateserver.xml
@@ -179,4 +179,22 @@
         <sha256>fa0239b9cd2e28a3dde5861572989ca2857814df2159157fb98fffd61efeba79</sha256>
         <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
     </update>
+    <update>
+        <name>Task - Delete trashed items</name>
+        <description>Joomla! Task - Delete trashed items Plugin</description>
+        <element>deltrash</element>
+        <type>plugin</type>
+        <folder>task</folder>
+        <version>1.7.2</version>
+        <client>site</client>
+        <php_minimum>8.1</php_minimum>
+        <infourl title="Joomla! Task - Delete trashed items Plugin">https://www.alikonweb.it/extensions/task-plugin-delete-trashed</infourl>
+        <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/plugins/task/deltrash/changelog.xml</changelogurl>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2/plg_task_deltrash-1.7.2.zip</downloadurl>
+        </downloads>
+        <tags><tag>stable</tag></tags>
+        <sha256>fa0239b9cd2e28a3dde5861572989ca2857814df2159157fb98fffd61efeba79</sha256>
+        <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
+    </update>
 </updates>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include the GitHub changelog URL in the warning alert when the changelog cannot be loaded.