### PR TITLE
Change heading styles in default.php template

### DIFF
--- a/src/modules/mod_changelog/field/links.php
+++ b/src/modules/mod_changelog/field/links.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @package     Joomla.Module
+ * @subpackage  Module.changelog
+ *
+ * @copyright   Copyright (C) 2026 Alikon. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 
 \defined('_JEXEC') or die;
 

--- a/src/modules/mod_changelog/field/version.php
+++ b/src/modules/mod_changelog/field/version.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @package     Joomla.Module
+ * @subpackage  Module.changelog
+ *
+ * @copyright   Copyright (C) 2026 Alikon. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 
 \defined('_JEXEC') or die;
 

--- a/src/modules/mod_changelog/services/provider.php
+++ b/src/modules/mod_changelog/services/provider.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @package     Joomla.Module
+ * @subpackage  Module.changelog
+ *
+ * @copyright   Copyright (C) 2026 Alikon. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 
 \defined('_JEXEC') or die;
 

--- a/src/modules/mod_changelog/src/Dispatcher/Dispatcher.php
+++ b/src/modules/mod_changelog/src/Dispatcher/Dispatcher.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * @package     Joomla.Module
+ * @subpackage  Module.changelog
+ *
+ * @copyright   Copyright (C) 2026 Alikon. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 
 namespace Alikonweb\Module\Changelog\Site\Dispatcher;
 

--- a/src/modules/mod_changelog/src/Helper/ChangelogHelper.php
+++ b/src/modules/mod_changelog/src/Helper/ChangelogHelper.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * @package     Joomla.Module
+ * @subpackage  Module.changelog
+ *
+ * @copyright   Copyright (C) 2026 Alikon. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
 namespace Alikonweb\Module\Changelog\Site\Helper;
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Http\HttpFactory;
 use Joomla\Registry\Registry;

--- a/src/modules/mod_changelog/tmpl/default.php
+++ b/src/modules/mod_changelog/tmpl/default.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * @package     Joomla.Module
+ * @subpackage  Module.changelog
+ *
+ * @copyright   Copyright (C) 2026 Alikon. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
 \defined('_JEXEC') or die;
 ?>
 

--- a/src/modules/mod_changelog/tmpl/default.php
+++ b/src/modules/mod_changelog/tmpl/default.php
@@ -3,7 +3,7 @@
 ?>
 
 <div class="mod-changelog shadow-sm p-3 mb-5 bg-body rounded">
-    <h3 class="mb-4 border-bottom pb-2">Project Updates</h3>
+    <h3 class="mb-4 border-bottom pb-2" style="font-style: normal;">Project Updates</h3>
     
     <?php if (!$list || empty($list)): ?>
         <div class="alert alert-warning">Unable to load changelog from GitHub <?php echo htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></div>
@@ -12,10 +12,10 @@
             <?php foreach ($list as $item): ?>
                 <div class="list-group-item py-3">
                     <div class="d-flex w-100 justify-content-between align-items-center mb-2">
-                        <h5 class="mb-1 fw-bold text-primary">
+                        <h4 class="mb-1 fw-bold text-primary-emphasis">
                             Version <?php echo htmlspecialchars($item->version); ?>
-                        </h5>
-                        <small class="badge bg-secondary opacity-75">
+                        </h4>
+                        <small class="badge bg-dark">
                             <?php echo htmlspecialchars($item->type); ?>
                         </small>
                     </div>
@@ -86,7 +86,7 @@
 
                         <?php if (isset($item->language) && !empty($item->language->item)): ?>
                             <div class="mb-3">
-                                <div class="small fw-bold text-primary mb-1">
+                                <div class="small fw-bold text-primary-emphasis mb-1">
                                     <i class="bi bi-translate"></i> LANGUAGE UPDATES
                                 </div>
                                 <ul class="ps-3 mb-0 small">


### PR DESCRIPTION
## Summary by Sourcery

Adjust changelog module template heading and label styling for improved visual hierarchy and emphasis.

Enhancements:
- Set the main changelog heading to use normal font style while preserving existing spacing and border styling.
- Promote version headings from h5 to h4 and update their color class to use the primary emphasis variant.
- Update the changelog item type badge to use a darker background style for stronger contrast.
- Align the language updates label color with the new primary emphasis text style.