### PR TITLE
Add field prefix to magiclogin XML configuration

### DIFF
--- a/src/plugins/system/magiclogin/language/en-GB/plg_system_magiclogin.ini
+++ b/src/plugins/system/magiclogin/language/en-GB/plg_system_magiclogin.ini
@@ -17,7 +17,9 @@ PLG_SYSTEM_MAGICLOGIN_RATE_LIMIT_WINDOW_DESC="Time period for counting rate limi
 PLG_SYSTEM_MAGICLOGIN_EMAIL_HTMLBODY="<p>Hi {USERNAME},</p><p>Click the link below to login:</p><p><a href='{MAGIC_LINK}'>Login Now</a></p><p>This link expires in {EXPIRY_MINUTES} minutes.</p><p>Best regards,<br>{SITENAME}</p>"
 PLG_SYSTEM_MAGICLOGIN_MAIL_MAGICLINK_TITLE="Your Magic Login Link"
 PLG_SYSTEM_MAGICLOGIN_MAIL_MAGICLINK_DESC="Email template for sending magic login links"
-PLG_SYSTEM_MAGICLOGIN_VERSION_LABEL="Plugin Version"
+PLG_SYSTEM_MAGICLOGIN_REDIRECT_URL_LABEL="Redirect After Login"
+PLG_SYSTEM_MAGICLOGIN_REDIRECT_URL_DESC="Select the menu item to redirect to after a successful magic link login. Leave empty to stay on the current page."
+
 PLG_SYSTEM_MAGICLOGIN_LINKS_LABEL="Resources"
 
 ; Clean Labels
@@ -26,3 +28,4 @@ PLG_SYSTEM_MAGICLOGIN_LBL_MANUAL="Manual"
 PLG_SYSTEM_MAGICLOGIN_LBL_FOLLOW="Follow"
 PLG_SYSTEM_MAGICLOGIN_LBL_REPORT="Report Issues"
 PLG_SYSTEM_MAGICLOGIN_LBL_SPONSOR="Sponsor"
+PLG_SYSTEM_MAGICLOGIN_VERSION_LABEL="Plugin Version"

--- a/src/plugins/system/magiclogin/magiclogin.xml
+++ b/src/plugins/system/magiclogin/magiclogin.xml
@@ -20,7 +20,7 @@
     </files>
 
     <config>
-        <fields name="params"  addfieldpath="/plugins/system/magiclogin/field">
+        <fields name="params" addfieldpath="/plugins/system/magiclogin/field" addfieldprefix="Joomla\Component\Menus\Administrator\Field">
             <fieldset name="basic">
                 <field name="license" type="note" 
                     label="PLG_SYSTEM_MAGICLOGIN_GPL_LICENSE" 
@@ -64,6 +64,20 @@
                        min="1"
                        max="60"
                        showon="rate_limit_enabled:1" />
+                
+                <field
+                    name="login"
+                    type="modal_menu"
+                    label="PLG_SYSTEM_MAGICLOGIN_REDIRECT_URL_LABEL"
+                    description="PLG_SYSTEM_MAGICLOGIN_REDIRECT_URL_DESC"
+                    disable="separator,alias,heading,url"
+                    select="true"
+                    new="true"
+                    edit="true"
+                    clear="true"
+                    >
+                    <option value="">JOPTION_SELECT_MENU_ITEM</option>
+                </field>
             </fieldset>
         </fields>
     </config>

--- a/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
+++ b/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
@@ -15,6 +15,7 @@ namespace Joomla\Plugin\System\MagicLogin\Extension;
 
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\MailTemplate;
@@ -291,7 +292,25 @@ final class MagicLogin extends CMSPlugin implements SubscriberInterface
             $db->setQuery($query)->execute();
 
             $this->app->enqueueMessage(Text::_('PLG_SYSTEM_MAGICLOGIN_LOGIN_SUCCESS'), 'success');
-            $this->app->redirect(Uri::base());
+
+            $returnMenuId = (int) $this->params->get('login', 0);
+            $url          = Uri::base();
+
+            if ($returnMenuId > 0) {
+                $item = $this->app->getMenu()->getItem($returnMenuId);
+
+                if ($item) {
+                    $lang = '';
+
+                    if ($item->language !== '*' && Multilanguage::isEnabled()) {
+                        $lang = '&lang=' . $item->language;
+                    }
+
+                    $url = Uri::base() . 'index.php?Itemid=' . $item->id . $lang;
+                }
+            }
+
+            $this->app->redirect($url);
         }
     }
 

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -71,10 +71,10 @@ describe('Test that the magiclogin system plugin', () => {
 
   it('redirects to configured menu item after login', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
-    // Get the menu item ID for com_users profile page and set it as the login redirect
-    cy.db_getMenuItemId('index.php?option=com_users&view=profile').then((itemId) => {
-      cy.db_updateExtensionParam('plg_system_magiclogin', 'login', itemId);
-    });
+    cy.db_createMenuItem({ title: 'User Profile', alias: 'user-profile', link: 'index.php?option=com_users&view=profile' })
+      .then((itemId) => {
+        cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
+      });
 
     loginWithEmail();
 

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -71,18 +71,19 @@ describe('Test that the magiclogin system plugin', () => {
 
   it('redirects to configured menu item after login', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
-    cy.db_createMenuItem({ title: 'User Profile', alias: 'user-profile', link: 'index.php?option=com_users&view=profile' })
-      .then((itemId) => {
+    cy.task('queryDB', "SELECT id FROM #__menu WHERE published = 1 AND client_id = 0 AND parent_id = 1 LIMIT 1")
+      .then((rows) => {
+        const itemId = rows[0].id;
         cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
+
+        loginWithEmail();
+
+        getTokenFromMail().then((token) => {
+          cy.visit(`/?magic_token=${token}`);
+          cy.checkForSystemMessage('You have been successfully logged in');
+          cy.url().should('include', `Itemid=${itemId}`);
+        });
       });
-
-    loginWithEmail();
-
-    getTokenFromMail().then((token) => {
-      cy.visit(`/?magic_token=${token}`);
-      cy.checkForSystemMessage('You have been successfully logged in');
-      cy.url().should('include', 'Itemid=');
-    });
   });
 
   it('rejects invalid magic token', () => {

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -82,25 +82,26 @@ describe('Test that the magiclogin system plugin', () => {
       link: 'index.php?option=com_content&view=featured',
       alias: 'after-login-page'
     })
-    .then((menuItem) => {
-      const itemId = menuItem.id;
-      const itemAlias = menuItem.alias ?? 'after-login-page';
+    .then(() => {
+      cy.task('queryDB', "SELECT id, alias FROM #__menu WHERE alias = 'after-login-page' AND published = 1 AND client_id = 0 LIMIT 1")
+        .then((rows) => {
+          expect(rows.length).to.be.greaterThan(0, 'Menu item was not created in DB');
 
-      cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
+          const itemId = rows[0].id;
 
-      loginWithEmail();
+          cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
 
-      getTokenFromMail().then((token) => {
-        cy.visit(`/?magic_token=${token}`);
-        cy.checkForSystemMessage('You have been successfully logged in');
+          loginWithEmail();
 
-        // Verify URL contains the alias of the configured redirect menu item
-        cy.url().should('include', itemAlias);
+          getTokenFromMail().then((token) => {
+            cy.visit(`/?magic_token=${token}`);
+            cy.checkForSystemMessage('You have been successfully logged in');
 
-        // Verify the redirect menu item is active in the navigation
-        cy.get(`a[href*="${itemAlias}"]`).should('have.class', 'active');
+            // Joomla redirects using Itemid in the URL, not the alias
+            cy.url().should('include', `Itemid=${itemId}`);
+          });
+        });
       });
-    });
   });
 
   it('rejects invalid magic token', () => {

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -70,21 +70,37 @@ describe('Test that the magiclogin system plugin', () => {
   });
 
   it('redirects to configured menu item after login', () => {
-    cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
-    cy.task('queryDB', "SELECT id, alias FROM #__menu WHERE published = 1 AND client_id = 0 AND parent_id = 1 LIMIT 1")
-      .then((rows) => {
-        const itemId = rows[0].id;
-        const itemAlias = rows[0].alias;
-        cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
+    cy.db_createUser({ 
+      name: 'Magic User', 
+      username: 'magicuser', 
+      email: 'magic@example.com', 
+      password: '098f6bcd4621d373cade4e832627b4f6' 
+    });
 
-        loginWithEmail();
+    cy.db_createMenuItem({ 
+      title: 'After Login Page', 
+      link: 'index.php?option=com_content&view=featured',
+      alias: 'after-login-page'
+    })
+    .then((menuItem) => {
+      const itemId = menuItem.id;
+      const itemAlias = menuItem.alias ?? 'after-login-page';
 
-        getTokenFromMail().then((token) => {
-          cy.visit(`/?magic_token=${token}`);
-          cy.checkForSystemMessage('You have been successfully logged in');
-          cy.url().should('include', itemAlias);
-        });
+      cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
+
+      loginWithEmail();
+
+      getTokenFromMail().then((token) => {
+        cy.visit(`/?magic_token=${token}`);
+        cy.checkForSystemMessage('You have been successfully logged in');
+
+        // Verify URL contains the alias of the configured redirect menu item
+        cy.url().should('include', itemAlias);
+
+        // Verify the redirect menu item is active in the navigation
+        cy.get(`a[href*="${itemAlias}"]`).should('have.class', 'active');
       });
+    });
   });
 
   it('rejects invalid magic token', () => {

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -70,6 +70,9 @@ describe('Test that the magiclogin system plugin', () => {
   });
 
   it('redirects to configured menu item after login', () => {
+    const uniqueAlias = `magic-redirect-${Date.now()}`;
+
+    // 1. Create a fresh user
     cy.db_createUser({ 
       name: 'Magic User', 
       username: 'magicuser', 
@@ -77,28 +80,37 @@ describe('Test that the magiclogin system plugin', () => {
       password: '098f6bcd4621d373cade4e832627b4f6' 
     });
 
-    // Use an existing published menu item instead of creating one that might 404
-    cy.task('queryDB', "SELECT id, alias FROM #__menu WHERE published = 1 AND client_id = 0 AND parent_id = 1 LIMIT 1")
-      .then((rows) => {
-        expect(rows.length).to.be.greaterThan(0, 'No published menu item found in DB');
+    // 2. Create a new menu item using the custom command
+    // The command handles lft/rgt and component_id automatically
+    cy.db_createMenuItem({
+      title: 'Magic Redirect Page',
+      alias: uniqueAlias,
+      path: uniqueAlias,
+      link: 'index.php?option=com_content&view=featured', // A standard Joomla view
+      menutype: 'mainmenu',
+      published: 1,
+    }).then((itemId) => {
+      cy.log(`Created redirect menu item with ID: ${itemId}`);
 
-        const itemId = rows[0].id;
-        const itemAlias = rows[0].alias;
+      // 3. Configure the plugin to use this new Itemid
+      cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
 
-        cy.log(`Using redirect menu item: id=${itemId}, alias=${itemAlias}`);
+      // 4. Perform the login flow
+      loginWithEmail();
 
-        cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
+      getTokenFromMail().then((token) => {
+        // Visit the magic link
+        cy.visit(`/?magic_token=${token}`);
 
-        loginWithEmail();
+        // 5. Assertions
+        cy.checkForSystemMessage('You have been successfully logged in');
 
-        getTokenFromMail().then((token) => {
-          cy.visit(`/?magic_token=${token}`);
-          cy.checkForSystemMessage('You have been successfully logged in');
-
-          // Joomla redirects using Itemid in the URL
-          cy.url().should('include', `Itemid=${itemId}`);
-        });
+        // Verify the redirect. Using a regex covers both:
+        // - Standard URLs: index.php?Itemid=123
+        // - SEF URLs: /magic-redirect-page
+        cy.url().should('match', new RegExp(`Itemid=${itemId}|/${uniqueAlias}`));
       });
+    });
   });
   
   it('rejects invalid magic token', () => {

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -9,6 +9,19 @@ describe('Test that the magiclogin system plugin', () => {
     });
   });
 
+  const loginWithEmail = () => {
+    cy.visit('/index.php?option=com_users&view=login');
+    cy.get('#username').type('magic@example.com');
+    cy.get('#password').type('1');
+    cy.get('.controls > button[type="submit"].btn').click();
+  };
+
+  const getTokenFromMail = () =>
+    cy.task('getMails').then((mails) => {
+      const htmlContent = String(mails[0].html || mails[0].body || '');
+      return htmlContent.match(/magic_token=([a-f0-9]+)/)[1];
+    });
+
   it('sends magic link when user enters email address', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
     
@@ -41,27 +54,34 @@ describe('Test that the magiclogin system plugin', () => {
   it('can login using magic link from email', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
     
-    cy.visit('/index.php?option=com_users&view=login');
-    cy.get('#username').type('magic@example.com');
-    cy.get('#password').type('1');
-    cy.get('.controls > button[type="submit"].btn').click();
+    loginWithEmail();
     
-    cy.task('getMails').then((mails) => {
-      cy.wrap(mails).should('have.lengthOf', 1);
-      
-      const htmlContent = String(mails[0].html || mails[0].body || '');
-      const magicLinkMatch = htmlContent.match(/magic_token=([a-f0-9]+)/);
-      
-      cy.wrap(magicLinkMatch).should('not.be.null');
-      
-      const token = magicLinkMatch[1];
+    getTokenFromMail().then((token) => {
       cy.wrap(token).should('have.length.greaterThan', 0);
       
       cy.visit(`/?magic_token=${token}`);
       cy.checkForSystemMessage('You have been successfully logged in');
+      // No redirect configured: should stay on homepage
+      cy.url().should('eq', Cypress.config('baseUrl') + '/');
       
       cy.visit('/index.php?option=com_users&view=login');
       cy.get('.com-users-logout').should('contain.text', 'Log out');
+    });
+  });
+
+  it('redirects to configured menu item after login', () => {
+    cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
+    // Get the menu item ID for com_users profile page and set it as the login redirect
+    cy.db_getMenuItemId('index.php?option=com_users&view=profile').then((itemId) => {
+      cy.db_updateExtensionParam('plg_system_magiclogin', 'login', itemId);
+    });
+
+    loginWithEmail();
+
+    getTokenFromMail().then((token) => {
+      cy.visit(`/?magic_token=${token}`);
+      cy.checkForSystemMessage('You have been successfully logged in');
+      cy.url().should('include', 'Itemid=');
     });
   });
 
@@ -73,22 +93,12 @@ describe('Test that the magiclogin system plugin', () => {
   it('rejects expired magic token', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
     
-    cy.visit('/index.php?option=com_users&view=login');
-    cy.get('#username').type('magic@example.com');
-    cy.get('#password').type('1');
-    cy.get('.controls > button[type="submit"].btn').click();
+    loginWithEmail();
     
-    cy.task('getMails').then((mails) => {
-      cy.wrap(mails).should('have.lengthOf', 1);
-      
-      const htmlContent = String(mails[0].html || mails[0].body || '');
-      const magicLinkMatch = htmlContent.match(/magic_token=([a-f0-9]+)/);
-      const token = magicLinkMatch[1];
-      
-      const dbType = Cypress.env('db_type'); 
-
-      const query = dbType === 'pgsql' 
-        ? "UPDATE #__magiclogin_tokens SET expires = NOW() - INTERVAL '1 hour'" 
+    getTokenFromMail().then((token) => {
+      const dbType = Cypress.env('db_type');
+      const query = dbType === 'pgsql'
+        ? "UPDATE #__magiclogin_tokens SET expires = NOW() - INTERVAL '1 hour'"
         : "UPDATE #__magiclogin_tokens SET expires = DATE_SUB(NOW(), INTERVAL 1 HOUR)";
 
       cy.task('queryDB', query);
@@ -145,18 +155,9 @@ describe('Test that the magiclogin system plugin', () => {
   it('token can only be used once', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
     
-    cy.visit('/index.php?option=com_users&view=login');
-    cy.get('#username').type('magic@example.com');
-    cy.get('#password').type('1');
-    cy.get('.controls > button[type="submit"].btn').click();
+    loginWithEmail();
     
-    cy.task('getMails').then((mails) => {
-      cy.wrap(mails).should('have.lengthOf', 1);
-      
-      const htmlContent = String(mails[0].html || mails[0].body || '');
-      const magicLinkMatch = htmlContent.match(/magic_token=([a-f0-9]+)/);
-      const token = magicLinkMatch[1];
-      
+    getTokenFromMail().then((token) => {
       cy.visit(`/?magic_token=${token}`);
       cy.checkForSystemMessage('You have been successfully logged in');
       
@@ -170,18 +171,9 @@ describe('Test that the magiclogin system plugin', () => {
   it('validates IP address and user agent', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
     
-    cy.visit('/index.php?option=com_users&view=login');
-    cy.get('#username').type('magic@example.com');
-    cy.get('#password').type('1');
-    cy.get('.controls > button[type="submit"].btn').click();
+    loginWithEmail();
     
-    cy.task('getMails').then((mails) => {
-      cy.wrap(mails).should('have.lengthOf', 1);
-      
-      const htmlContent = String(mails[0].html || mails[0].body || '');
-      const magicLinkMatch = htmlContent.match(/magic_token=([a-f0-9]+)/);
-      const token = magicLinkMatch[1];
-      
+    getTokenFromMail().then((token) => {
       cy.task('queryDB', "UPDATE #__magiclogin_tokens SET ip_address = '999.999.999.999'");
       
       cy.visit(`/?magic_token=${token}`);

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -77,33 +77,30 @@ describe('Test that the magiclogin system plugin', () => {
       password: '098f6bcd4621d373cade4e832627b4f6' 
     });
 
-    cy.db_createMenuItem({ 
-      title: 'After Login Page', 
-      link: 'index.php?option=com_content&view=featured',
-      alias: 'after-login-page'
-    })
-    .then(() => {
-      cy.task('queryDB', "SELECT id, alias FROM #__menu WHERE alias = 'after-login-page' AND published = 1 AND client_id = 0 LIMIT 1")
-        .then((rows) => {
-          expect(rows.length).to.be.greaterThan(0, 'Menu item was not created in DB');
+    // Use an existing published menu item instead of creating one that might 404
+    cy.task('queryDB', "SELECT id, alias FROM #__menu WHERE published = 1 AND client_id = 0 AND parent_id = 1 LIMIT 1")
+      .then((rows) => {
+        expect(rows.length).to.be.greaterThan(0, 'No published menu item found in DB');
 
-          const itemId = rows[0].id;
+        const itemId = rows[0].id;
+        const itemAlias = rows[0].alias;
 
-          cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
+        cy.log(`Using redirect menu item: id=${itemId}, alias=${itemAlias}`);
 
-          loginWithEmail();
+        cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
 
-          getTokenFromMail().then((token) => {
-            cy.visit(`/?magic_token=${token}`);
-            cy.checkForSystemMessage('You have been successfully logged in');
+        loginWithEmail();
 
-            // Joomla redirects using Itemid in the URL, not the alias
-            cy.url().should('include', `Itemid=${itemId}`);
-          });
+        getTokenFromMail().then((token) => {
+          cy.visit(`/?magic_token=${token}`);
+          cy.checkForSystemMessage('You have been successfully logged in');
+
+          // Joomla redirects using Itemid in the URL
+          cy.url().should('include', `Itemid=${itemId}`);
         });
       });
   });
-
+  
   it('rejects invalid magic token', () => {
     cy.visit('/?magic_token=invalidtoken123456789');
     cy.checkForSystemMessage('This magic link is invalid or has expired');

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -71,9 +71,10 @@ describe('Test that the magiclogin system plugin', () => {
 
   it('redirects to configured menu item after login', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
-    cy.task('queryDB', "SELECT id FROM #__menu WHERE published = 1 AND client_id = 0 AND parent_id = 1 LIMIT 1")
+    cy.task('queryDB', "SELECT id, alias FROM #__menu WHERE published = 1 AND client_id = 0 AND parent_id = 1 LIMIT 1")
       .then((rows) => {
         const itemId = rows[0].id;
+        const itemAlias = rows[0].alias;
         cy.db_updateExtensionParameter('login', itemId, 'plg_system_magiclogin');
 
         loginWithEmail();
@@ -81,7 +82,7 @@ describe('Test that the magiclogin system plugin', () => {
         getTokenFromMail().then((token) => {
           cy.visit(`/?magic_token=${token}`);
           cy.checkForSystemMessage('You have been successfully logged in');
-          cy.url().should('include', `Itemid=${itemId}`);
+          cy.url().should('include', itemAlias);
         });
       });
   });


### PR DESCRIPTION
## Summary by Sourcery

Add configurable post-login redirection for magic link logins and update tests accordingly.

New Features:
- Allow configuring a menu item to redirect users to after a successful magic link login.

Enhancements:
- Default magic link logins to remain on the homepage when no redirect is configured.
- Support multilingual-aware redirects by including the menu item language in the redirect URL when applicable.

Documentation:
- Document the new redirect-after-login option in the magiclogin plugin language strings.

Tests:
- Refactor Cypress magic login tests to reuse shared login and mail helper functions.
- Add an end-to-end test verifying redirection to the configured menu item after magic link login.