### PR TITLE
[mod_github_portfolio] support  for dark mode

### DIFF
--- a/src/modules/mod_github_portfolio/changelog.xml
+++ b/src/modules/mod_github_portfolio/changelog.xml
@@ -3,33 +3,16 @@
         <element>mod_github_portfolio</element>
         <type>module</type>
         <version>1.0.0</version>
-        <security>
-            <item>Item A</item>
-            <item>Item b</item>
-        </security>
-        <fix>
-            <item>Item A</item>
-            <item>Item b</item>
-        </fix>
-        <language>
-            <item>Item A</item>
-            <item>Item b</item>
-        </language>
-        <addition>
-            <item>Item A</item>
-            <item>Item b</item>
-        </addition>
-        <change>
-            <item>Item A</item>
-            <item>Item b</item>
-        </change>
-        <remove>
-            <item>Item A</item>
-            <item>Item b</item>
-        </remove>
         <note>
-            <item>Item A</item>
-            <item>Item b</item>
+            <item>Listed on JED</item>
         </note>
+    </changelog>
+    <changelog>
+        <element>mod_github_portfolio</element>
+        <type>module</type>
+        <version>1.1.0</version>
+        <addition>
+            <item>Dark mode</item>
+        </addition>        
     </changelog>
 </changelogs>

--- a/src/modules/mod_github_portfolio/media/css/github-portfolio.css
+++ b/src/modules/mod_github_portfolio/media/css/github-portfolio.css
@@ -1,0 +1,33 @@
+/* GitHub Portfolio Module Styles */
+
+.github-portfolio-module .pr-card {
+    border-radius: 8px;
+    transition: all 0.3s ease;
+}
+
+.github-portfolio-module .pr-card .btn-outline-primary {
+    border-width: 2px;
+    font-weight: 600;
+}
+
+.github-portfolio-module .pr-card .btn-outline-primary:hover {
+    transform: translateY(-2px);
+}
+
+.github-portfolio-module .status-badge {
+    font-size: 0.7rem;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .github-portfolio-module .container {
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+    
+    .github-portfolio-module .pr-card {
+        margin-bottom: 1.5rem;
+    }
+}

--- a/src/modules/mod_github_portfolio/media/css/github-portfolio.css
+++ b/src/modules/mod_github_portfolio/media/css/github-portfolio.css
@@ -1,16 +1,22 @@
 /* GitHub Portfolio Module Styles */
 
-.github-portfolio-module .pr-card {
+/* Supporta sia .pr-card (retrocompatibilità) che .github-portfolio-card */
+.github-portfolio-module .pr-card,
+.github-portfolio-module .github-portfolio-card {
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
     border-radius: 8px;
     transition: all 0.3s ease;
 }
 
-.github-portfolio-module .pr-card .btn-outline-primary {
+.github-portfolio-module .pr-card .btn-outline-primary,
+.github-portfolio-module .github-portfolio-card .btn-outline-primary {
     border-width: 2px;
     font-weight: 600;
 }
 
-.github-portfolio-module .pr-card .btn-outline-primary:hover {
+.github-portfolio-module .pr-card .btn-outline-primary:hover,
+.github-portfolio-module .github-portfolio-card .btn-outline-primary:hover {
     transform: translateY(-2px);
 }
 
@@ -20,14 +26,25 @@
     text-transform: uppercase;
 }
 
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+    .github-portfolio-module .pr-card,
+    .github-portfolio-module .github-portfolio-card {
+        background-color: #1e2530;
+        border-color: #3d4a5c;
+        color: #e2e8f0;
+    }
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .github-portfolio-module .container {
         padding-left: 15px;
         padding-right: 15px;
     }
-    
-    .github-portfolio-module .pr-card {
+
+    .github-portfolio-module .pr-card,
+    .github-portfolio-module .github-portfolio-card {
         margin-bottom: 1.5rem;
     }
 }

--- a/src/modules/mod_github_portfolio/media/js/github-portfolio.js
+++ b/src/modules/mod_github_portfolio/media/js/github-portfolio.js
@@ -40,7 +40,6 @@ document.addEventListener('DOMContentLoaded', () => {
           localStorage.setItem(cacheKey, JSON.stringify(data));
           localStorage.setItem(`${cacheKey}_time`, String(Date.now()));
         } catch (e) {
-          // localStorage might be full or disabled; just ignore
           console.warn('mod_github_portfolio: unable to store cache.', e);
         }
         renderData(data, container);
@@ -93,9 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
       col.className = 'col-lg-4 col-md-6 col-sm-12 mb-4';
 
       const card = document.createElement('div');
-      card.className = 'p-4 rounded shadow h-100';
-      card.style.backgroundColor = '#f8f9fa';
-      card.style.border = '1px solid #dee2e6';
+      card.className = 'p-4 rounded shadow h-100 github-portfolio-card';
 
       const h4 = document.createElement('h4');
       h4.textContent = title;

--- a/src/modules/mod_github_portfolio/mod_github_portfolio.xml
+++ b/src/modules/mod_github_portfolio/mod_github_portfolio.xml
@@ -5,7 +5,7 @@
     <creationDate>2025-12-01</creationDate>
     <copyright>Copyright (C) 2021 Alikon. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <description>MOD_GITHUB_PORTFOLIO_XML_DESCRIPTION</description>
     <namespace path="src">Joomla\Module\GithubPortfolio</namespace>
     <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/modules/mod_github_portfolio/changelog.xml</changelogurl>

--- a/src/modules/mod_github_portfolio/mod_github_portfolio.xml
+++ b/src/modules/mod_github_portfolio/mod_github_portfolio.xml
@@ -11,6 +11,7 @@
     <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/modules/mod_github_portfolio/changelog.xml</changelogurl>
     <media destination="mod_github_portfolio" folder="media">
         <folder>js</folder>
+		<folder>css</folder>
     </media>
     <files>
         <folder module="mod_github_portfolio">services</folder>

--- a/src/modules/mod_github_portfolio/tmpl/default.php
+++ b/src/modules/mod_github_portfolio/tmpl/default.php
@@ -19,6 +19,14 @@ $wa  = $app->getDocument()->getWebAssetManager();
 // Core JS if you still need it elsewhere
 $wa->useScript('core');
 
+// Register & use dedicated CSS asset for dark mode support
+$wa->registerAndUseStyle(
+    'mod_github_portfolio.github-portfolio',
+    'mod_github_portfolio/github-portfolio.css',
+    [],
+    []
+);
+
 // Register & use dedicated JS asset
 $wa->registerAndUseScript(
     'mod_github_portfolio.github-portfolio',

--- a/src/modules/mod_github_portfolio/updateserver.xml
+++ b/src/modules/mod_github_portfolio/updateserver.xml
@@ -17,4 +17,21 @@
         <sha256>e4d427b2bc58db2767e75d845b1b2e2fcf98bb9a552bb1a2bbdd62ef7ec61a0c</sha256>
         <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
     </update>
+    <update>
+        <name>Module - Github Porfolio</name>
+        <description>Joomla! Module - Github Porfolio</description>
+        <element>mod_github_portfolio</element>
+        <type>module</type>
+        <version>1.1.0</version>
+        <client>site</client>
+        <php_minimum>8.1</php_minimum>
+        <infourl title="Joomla! Module - Github Porfolio">https://www.alikonweb.it</infourl>
+        <changelogurl>https://raw.githubusercontent.com/alikon/testcom/main/src/modules/mod_github_portfolio/changelog.xml</changelogurl>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/alikon/testcom/releases/download/v1.2.1/mod_github_portfolio-1.1.0.zip</downloadurl>
+        </downloads>
+        <tags><tag>stable</tag></tags>
+        <sha256>e4d427b2bc58db2767e75d845b1b2e2fcf98bb9a552bb1a2bbdd62ef7ec61a0c</sha256>
+        <targetplatform name="joomla" version="((5\.[01234])|(6\.[01234]))" />
+    </update>
 </updates>


### PR DESCRIPTION
## Summary by Sourcery

Add a dedicated stylesheet and CSS classes for the GitHub portfolio module to support dark mode and responsive styling, and wire it into the module assets.

Enhancements:
- Move inline card styling to a reusable CSS class shared between legacy and new markup to improve maintainability and consistency.

Build:
- Register the new CSS media folder and asset in the module manifest so the stylesheet is included with the module.