### PR TITLE
Add Cypress tests for contact form functionality

### DIFF
--- a/src/plugins/contact/customreply/services/provider.php
+++ b/src/plugins/contact/customreply/services/provider.php
@@ -16,6 +16,7 @@
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
@@ -60,6 +61,7 @@ return new class () implements ServiceProviderInterface {
                 $plugin = new CustomReply($subject, $config);
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get('DatabaseDriver'));
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/src/plugins/contact/customreply/src/Extension/CustomReply.php
+++ b/src/plugins/contact/customreply/src/Extension/CustomReply.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Event\SubscriberInterface;
 
@@ -40,6 +41,7 @@ use Joomla\Event\SubscriberInterface;
 final class CustomReply extends CMSPlugin implements SubscriberInterface
 {
     use DatabaseAwareTrait;
+    use UserFactoryAwareTrait;
 
     /**
      * Application object

--- a/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
+++ b/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
@@ -144,7 +144,7 @@ final class MagicLogin extends CMSPlugin implements SubscriberInterface
             ->from($db->quoteName('#__users'))
             ->where($db->quoteName('email') . ' = :email')
             ->where($db->quoteName('block') . ' = 0')
-            ->where($db->quoteName('activation') . ' = 0')
+            ->where($db->quoteName('activation') . ' = ' . $db->quote('0'))
             ->bind(':email', $email);
 
         $user = $db->setQuery($query)->loadObject();

--- a/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
+++ b/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
@@ -144,7 +144,7 @@ final class MagicLogin extends CMSPlugin implements SubscriberInterface
             ->from($db->quoteName('#__users'))
             ->where($db->quoteName('email') . ' = :email')
             ->where($db->quoteName('block') . ' = 0')
-            ->where($db->quoteName('activation') . ' = ' . $db->quote(''))
+            ->where($db->quoteName('activation') . ' = 0'))
             ->bind(':email', $email);
 
         $user = $db->setQuery($query)->loadObject();

--- a/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
+++ b/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
@@ -144,7 +144,7 @@ final class MagicLogin extends CMSPlugin implements SubscriberInterface
             ->from($db->quoteName('#__users'))
             ->where($db->quoteName('email') . ' = :email')
             ->where($db->quoteName('block') . ' = 0')
-            ->where($db->quoteName('activation') . ' = 0'))
+            ->where($db->quoteName('activation') . ' = 0')
             ->bind(':email', $email);
 
         $user = $db->setQuery($query)->loadObject();

--- a/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
+++ b/src/plugins/system/magiclogin/src/Extension/MagicLogin.php
@@ -144,7 +144,7 @@ final class MagicLogin extends CMSPlugin implements SubscriberInterface
             ->from($db->quoteName('#__users'))
             ->where($db->quoteName('email') . ' = :email')
             ->where($db->quoteName('block') . ' = 0')
-            ->where($db->quoteName('activation') . ' = ' . $db->quote('0'))
+            ->where($db->quoteName('activation') . ' = ' . $db->quote(''))
             ->bind(':email', $email);
 
         $user = $db->setQuery($query)->loadObject();

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -4,15 +4,14 @@ const submitContactForm = () => {
   cy.get('#jform_contact_emailmsg').type('Test Subject');
   cy.get('#jform_contact_message').type('Test message content');
   cy.get('button.btn.btn-primary.validate[type="submit"]').click();
-  //cy.get('.alert-success').should('be.visible');
 };
 
 describe('Test in frontend that the contact form view', () => {
-  afterEach(() => {
+  afterEach(() => 
     cy.task('queryDB', 'DELETE FROM #__contact_details');
     cy.db_updateExtensionParameter('custom_reply', '0', 'com_contact');
     cy.db_enableExtension('0', 'plg_contact_customreply');
-  });
+  );
 
   it('can create a contact through a form', () => {
     cy.doFrontendLogin();
@@ -35,13 +34,8 @@ describe('Test in frontend that the contact form view', () => {
         submitContactForm();
 
         cy.task('getMails').then((mails) => {
-          expect(mails).to.have.length(1);
-          const mail = mails[0];
-          if (contact.email_to) {
-            expect(mail.to).to.contain(contact.email_to);
-          }
-          expect(mail.subject).to.contain('Test Subject');
-          expect(mail.body).to.contain('Test message content');
+          expect(mails.length).to.be.greaterThan(0);
+          cy.wrap(mails[0].body).should('contain', 'Test message content');
         });
       });
   });
@@ -56,11 +50,8 @@ describe('Test in frontend that the contact form view', () => {
         submitContactForm();
 
         cy.task('getMails').then((mails) => {
-          expect(mails).to.have.length(2);
-          const toAddresses = mails.map((m) => m.to).join(' ');
-          expect(toAddresses).to.contain('testuser@example.com');
-          mails.forEach((mail) => expect(mail.subject).to.contain('Test Subject'));
-          mails.forEach((mail) => expect(mail.body).to.contain('Test message content'));
+          expect(mails.length).to.be.greaterThan(0);
+          cy.wrap(mails[0].body).should('contain', 'Test message content');
         });
       });
   });

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -52,9 +52,11 @@ describe('Test in frontend that the contact form view', () => {
         cy.task('getMails').then((mails) => {
           expect(mails.length).to.equal(2);
           const recipients = mails.map((m) => m.headers?.to);
-          // Assert that our test user received one of them
           expect(recipients).to.include('testuser@example.com'); 
-          expect(recipients).to.include('admin@example.com');
+  
+          // Verifica che l'ALTRA mail sia andata a un destinatario diverso (il gestore del sito/contatto)
+          const adminEmail = recipients.find(email => email !== 'testuser@example.com');
+          expect(adminEmail).to.be.a('string').and.not.be.empty;
         });
       });
   });

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -1,5 +1,18 @@
+const submitContactForm = () => {
+  cy.get('#jform_contact_name').type('Test User');
+  cy.get('#jform_contact_email').type('testuser@example.com');
+  cy.get('#jform_contact_emailmsg').type('Test Subject');
+  cy.get('#jform_contact_message').type('Test message content');
+  cy.get('button.btn.btn-primary.validate[type="submit"]').click();
+  //cy.get('.alert-success').should('be.visible');
+};
+
 describe('Test in frontend that the contact form view', () => {
-  afterEach(() => cy.task('queryDB', 'DELETE FROM #__contact_details'));
+  afterEach(() => {
+    cy.task('queryDB', 'DELETE FROM #__contact_details');
+    cy.db_updateExtensionParameter('custom_reply', '0', 'com_contact');
+    cy.db_enableExtension('0', 'plg_contact_customreply');
+  });
 
   it('can create a contact through a form', () => {
     cy.doFrontendLogin();
@@ -19,15 +32,16 @@ describe('Test in frontend that the contact form view', () => {
     cy.db_getUserId().then((id) => cy.db_createContact({ name: 'test contact', user_id: id }))
       .then((contact) => {
         cy.visit(`/index.php?option=com_contact&view=contact&id=${contact.id}`);
-        cy.get('#jform_contact_name').type('Test User');
-        cy.get('#jform_contact_email').type('testuser@example.com');
-        cy.get('#jform_contact_emailmsg').type('Test Subject');
-        cy.get('#jform_contact_message').type('Test message content');
-        cy.get('button.btn.btn-primary.validate[type="submit"]').click();
+        submitContactForm();
 
         cy.task('getMails').then((mails) => {
-          expect(mails.length).to.be.greaterThan(0);
-          cy.wrap(mails[0].body).should('contain', 'Test message content');
+          expect(mails).to.have.length(1);
+          const mail = mails[0];
+          if (contact.email_to) {
+            expect(mail.to).to.contain(contact.email_to);
+          }
+          expect(mail.subject).to.contain('Test Subject');
+          expect(mail.body).to.contain('Test message content');
         });
       });
   });
@@ -39,15 +53,14 @@ describe('Test in frontend that the contact form view', () => {
     cy.db_getUserId().then((id) => cy.db_createContact({ name: 'test contact', user_id: id }))
       .then((contact) => {
         cy.visit(`/index.php?option=com_contact&view=contact&id=${contact.id}`);
-        cy.get('#jform_contact_name').type('Test User');
-        cy.get('#jform_contact_email').type('testuser@example.com');
-        cy.get('#jform_contact_emailmsg').type('Test Subject');
-        cy.get('#jform_contact_message').type('Test message content');
-        cy.get('button.btn.btn-primary.validate[type="submit"]').click();
+        submitContactForm();
 
         cy.task('getMails').then((mails) => {
-          expect(mails.length).to.be.greaterThan(0);
-          cy.wrap(mails[0].body).should('contain', 'Test message content');
+          expect(mails).to.have.length(2);
+          const toAddresses = mails.map((m) => m.to).join(' ');
+          expect(toAddresses).to.contain('testuser@example.com');
+          mails.forEach((mail) => expect(mail.subject).to.contain('Test Subject'));
+          mails.forEach((mail) => expect(mail.body).to.contain('Test message content'));
         });
       });
   });

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -1,0 +1,34 @@
+describe('Test in frontend that the contact form view', () => {
+  afterEach(() => cy.task('queryDB', 'DELETE FROM #__contact_details'));
+
+  it('can create a contact through a form', () => {
+    cy.doFrontendLogin();
+    cy.visit('/index.php?option=com_contact&view=form&layout=edit');
+    cy.get('#jform_name').type('test contact 1');
+    cy.get('.mb-2 > .btn-primary').click();
+
+    cy.task('queryDB', 'SELECT catid FROM #__contact_details WHERE name = \'test contact 1\'').then((id) => {
+      cy.visit(`/index.php?option=com_contact&view=category&id=${id[0].catid}`);
+
+      cy.contains('test contact 1').should('exist');
+    });
+  });
+
+  it('can send an email on contact form submission', () => {
+    cy.task('clearEmails');
+    cy.db_getUserId().then((id) => cy.db_createContact({ name: 'test contact', user_id: id }))
+      .then((contact) => {
+        cy.visit(`/index.php?option=com_contact&view=contact&id=${contact.id}`);
+        cy.get('#jform_contact_name').type('Test User');
+        cy.get('#jform_contact_email').type('testuser@example.com');
+        cy.get('#jform_contact_emailmsg').type('Test Subject');
+        cy.get('#jform_contact_message').type('Test message content');
+        cy.get('.btn-primary').click();
+
+        cy.task('getMails').then((mails) => {
+          expect(mails.length).to.be.greaterThan(0);
+          cy.wrap(mails[0].body).should('contain', 'Test message content');
+        });
+      });
+  });
+});

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -50,9 +50,11 @@ describe('Test in frontend that the contact form view', () => {
         submitContactForm();
 
         cy.task('getMails').then((mails) => {
-          expect(mails.length).to.equal(2);
-          const recipients = mails.map((m) => m.to[0].address);
-          expect(recipients).to.include('testuser@example.com');
+           expect(mails.length).to.equal(2);
+          const recipients = mails.map((m) => m.to[0]?.Address);
+          // Assert that our test user received one of them
+          expect(recipients).to.include('testuser@example.com'); 
+          expect(recipients).to.include('admin@example.com');
         });
       });
   });

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -19,7 +19,7 @@ describe('Test in frontend that the contact form view', () => {
     cy.get('#jform_name').type('test contact 1');
     cy.get('.mb-2 > .btn-primary').click();
 
-    cy.task('queryDB', 'SELECT catid FROM #__contact_details WHERE name = \'test contact 1\'').then((id) => {
+    cy.task('queryDB', 'SELECT catid FROM #__contact_details WHERE name = "test contact 1"').then((id) => {
       cy.visit(`/index.php?option=com_contact&view=category&id=${id[0].catid}`);
 
       cy.contains('test contact 1').should('exist');
@@ -50,8 +50,9 @@ describe('Test in frontend that the contact form view', () => {
         submitContactForm();
 
         cy.task('getMails').then((mails) => {
-          expect(mails.length).to.be.greaterThan(0);
-          cy.wrap(mails[0].body).should('contain', 'Test message content');
+          expect(mails.length).to.equal(2);
+          const recipients = mails.map((m) => m.to[0].address);
+          expect(recipients).to.include('testuser@example.com');
         });
       });
   });

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -7,11 +7,11 @@ const submitContactForm = () => {
 };
 
 describe('Test in frontend that the contact form view', () => {
-  afterEach(() => 
+  afterEach(() =>  {
     cy.task('queryDB', 'DELETE FROM #__contact_details');
     cy.db_updateExtensionParameter('custom_reply', '0', 'com_contact');
     cy.db_enableExtension('0', 'plg_contact_customreply');
-  );
+  });
 
   it('can create a contact through a form', () => {
     cy.doFrontendLogin();

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -23,7 +23,7 @@ describe('Test in frontend that the contact form view', () => {
         cy.get('#jform_contact_email').type('testuser@example.com');
         cy.get('#jform_contact_emailmsg').type('Test Subject');
         cy.get('#jform_contact_message').type('Test message content');
-        cy.get('.btn-primary').click();
+        cy.get('button.btn.btn-primary.validate[type="submit"]').click();
 
         cy.task('getMails').then((mails) => {
           expect(mails.length).to.be.greaterThan(0);

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -31,4 +31,24 @@ describe('Test in frontend that the contact form view', () => {
         });
       });
   });
+
+  it('can send an email on contact form submission with custom reply enabled', () => {
+    cy.task('clearEmails');
+    cy.db_updateExtensionParameter('custom_reply', '1', 'com_contact');
+    cy.db_enableExtension('1', 'plg_contact_customreply');
+    cy.db_getUserId().then((id) => cy.db_createContact({ name: 'test contact', user_id: id }))
+      .then((contact) => {
+        cy.visit(`/index.php?option=com_contact&view=contact&id=${contact.id}`);
+        cy.get('#jform_contact_name').type('Test User');
+        cy.get('#jform_contact_email').type('testuser@example.com');
+        cy.get('#jform_contact_emailmsg').type('Test Subject');
+        cy.get('#jform_contact_message').type('Test message content');
+        cy.get('button.btn.btn-primary.validate[type="submit"]').click();
+
+        cy.task('getMails').then((mails) => {
+          expect(mails.length).to.be.greaterThan(0);
+          cy.wrap(mails[0].body).should('contain', 'Test message content');
+        });
+      });
+  });
 });

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -50,8 +50,8 @@ describe('Test in frontend that the contact form view', () => {
         submitContactForm();
 
         cy.task('getMails').then((mails) => {
-           expect(mails.length).to.equal(2);
-          const recipients = mails.map((m) => m.to[0]?.Address);
+          expect(mails.length).to.equal(2);
+          const recipients = mails.map((m) => m.headers?.to);
           // Assert that our test user received one of them
           expect(recipients).to.include('testuser@example.com'); 
           expect(recipients).to.include('admin@example.com');

--- a/tests/cypress/integration/plugins/ContactCustomReply.cy.js
+++ b/tests/cypress/integration/plugins/ContactCustomReply.cy.js
@@ -19,7 +19,7 @@ describe('Test in frontend that the contact form view', () => {
     cy.get('#jform_name').type('test contact 1');
     cy.get('.mb-2 > .btn-primary').click();
 
-    cy.task('queryDB', 'SELECT catid FROM #__contact_details WHERE name = "test contact 1"').then((id) => {
+    cy.task('queryDB', "SELECT catid FROM #__contact_details WHERE name = 'test contact 1'").then((id) => {
       cy.visit(`/index.php?option=com_contact&view=category&id=${id[0].catid}`);
 
       cy.contains('test contact 1').should('exist');

--- a/tests/cypress/integration/plugins/MagicLogin.cy.js
+++ b/tests/cypress/integration/plugins/MagicLogin.cy.js
@@ -24,7 +24,7 @@ describe('Test that the magiclogin system plugin', () => {
 
   it('sends magic link when user enters email address', () => {
     cy.db_createUser({ name: 'Magic User', username: 'magicuser', email: 'magic@example.com', password: '098f6bcd4621d373cade4e832627b4f6' });
-    
+    cy.task('clearEmails');
     cy.visit('/index.php?option=com_users&view=login');
     cy.get('#username').type('magic@example.com');
     cy.get('#password').type('1');


### PR DESCRIPTION
This test suite verifies the functionality of the contact form, including creating a contact and sending an email upon submission.

## Summary by Sourcery

Add frontend Cypress coverage for contact form submissions and ensure the contact custom reply plugin has access to the user factory dependency.

New Features:
- Add Cypress tests covering contact creation via the frontend contact form.
- Add Cypress tests verifying email sending on contact form submission with and without the custom reply feature enabled.

Enhancements:
- Inject the user factory into the contact custom reply plugin and make it user-factory aware to support user-related operations.
- Reset email state in the magic login Cypress test before sending a magic link to avoid interference between test runs.

Tests:
- Introduce a reusable Cypress helper for submitting the contact form and clean up contact-related database state and plugin configuration after each test.