### PR TITLE
Enhance CI workflow for PHP code style checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           set -e
           ./libraries/vendor/bin/php-cs-fixer fix -vvv --diff
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "joomla/joomla-cms" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "alikon/testcom" ]; then
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,19 @@ jobs:
       - uses: ./.github/actions/setup-dependencies
       - name: Run PHP CS Fixer and PHPCS
         continue-on-error: true
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: true
         run: |
-          ./vendor/bin/php-cs-fixer fix -vvv --dry-run --diff
-          ./vendor/bin/phpcs --extensions=php -p --standard=ruleset.xml src/
+          set -e
+          ./libraries/vendor/bin/php-cs-fixer fix -vvv --diff
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "joomla/joomla-cms" ]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add --all
+            git commit -m "Fix code style issues [skip ci]"
+            git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
+          fi
 
 # -------------------------------------------------
 # NPM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,31 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: true
         run: |
+          # 1. Check for styling issues without changing files (Logs errors to the console)
+          ./vendor/bin/php-cs-fixer fix -vvv --dry-run --diff || true
+          ./vendor/bin/phpcs --extensions=php -p --standard=ruleset.xml src/ || true
+
+          # 2. Halt script immediately if any of the following modification/git steps fail
           set -e
-          ./libraries/vendor/bin/php-cs-fixer fix -vvv --diff
+
+          # 3. Apply actual fixes to the codebase
+          ./vendor/bin/php-cs-fixer fix -vvv --diff
+
+          # 4. Configure Git and safely push changes back to the repository
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "alikon/testcom" ]; then
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add --all
-            git commit -m "Fix code style issues [skip ci]"
-            git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
+            
+            # Only commit and push if there are actually modified files to commit
+            if ! git diff --staged --quiet; then
+              git commit -m "Fix code style issues [skip ci]"
+              git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
+            else
+              echo "No code style changes detected. Skipping commit."
+            fi
           fi
 
 # -------------------------------------------------


### PR DESCRIPTION
Added environment variable for PHP CS Fixer and updated the script to handle code style fixes automatically.

## Summary by Sourcery

Automate PHP code style enforcement in CI and allow the workflow to push fixes back to the repository when needed.

Enhancements:
- Run PHP CS Fixer and PHPCS in a two-phase process that first reports style issues and then applies fixes.
- Configure the CI job to commit and push automatic code style fixes back to the source branch when changes are detected.
- Set PHP_CS_FIXER_IGNORE_ENV in the workflow to ensure consistent PHP CS Fixer behavior across environments.