### PR TITLE
Update MySQL image to latest version

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,8 +14,7 @@ services:
     command: sleep infinity
 
   mysql:
-    image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password
+    image: mysql:latest
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Change the devcontainer docker-compose MySQL service to use the mysql:latest image instead of a pinned 8.0 tag and remove the custom authentication plugin command override.